### PR TITLE
Add notice on pre-built releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This asset can be prepared in two flavours:
 
 ## Releases
 
+> **Note:** The releases are built in overlay mode.
+
 The best way to start quickly is to use our releases.
 
 You can download pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/releases) of the Asset that support both platforms and specific ros2 and Unity3D versions.


### PR DESCRIPTION
I searched and found nowhere mention the releases is overlay mode. Then I download the release and found ROS2 installation is required.