### PR TITLE
Fix PostInstall.cs for Cross Building

### DIFF
--- a/src/Ros2ForUnity/Scripts/PostInstall.cs
+++ b/src/Ros2ForUnity/Scripts/PostInstall.cs
@@ -40,7 +40,7 @@ internal class PostInstall : IPostprocessBuildWithReport
         var execFilename = Path.GetFileNameWithoutExtension(report.summary.outputPath);
         FileUtil.CopyFileOrDirectory(
             r2fuMeta, outputDir + "/" + execFilename + "_Data/" + r2fuMetadataName);
-        if (ROS2ForUnity.GetOS() == ROS2ForUnity.Platform.Linux) {
+        if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.StandaloneLinux64) {
             FileUtil.CopyFileOrDirectory(
                 r2csMeta, outputDir + "/" + execFilename + "_Data/Plugins/" + r2csMetadataName);
         } else {


### PR DESCRIPTION
Since I had a trouble cross-building an unity application which uses ros2-for-unity, I've created a pull request.

When using Unity editor of Linux machine and trying to build a Windows application, `metadata_ros2cs.xml` will be copied to `_Data/Plugins/` directory (which is written in PostInstall.cs).

However, when running the built application on Windows machine, ros2-for-unity tries to load `metadata_ros2cs.xml` from `_Data/Plugins/x86_64` directory (which is written in ROS2ForUnity.cs), and it fails to load the xml file and the app will crash.

To solve this problem, I've fixed the PostInstall.cs to check target platform instead of the current OS.