### PR TITLE
Changed GetRos2ForUnityPath() to allow dynamic directory

### DIFF
--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -86,12 +86,22 @@ internal class ROS2ForUnity
     public static string GetRos2ForUnityPath()
     {
         char separator = Path.DirectorySeparatorChar;
-        string appDataPath = Application.dataPath;
-        string pluginPath = appDataPath;
+        string pluginPath = "";
 
-        if (InEditor()) {
-            pluginPath += separator + ros2ForUnityAssetFolderName;
+        var assetGUIs = AssetDatabase.FindAssets("t:Folder Ros2ForUnity");
+        if (assetGUIs.Length == 1)
+        {
+            pluginPath = AssetDatabase.GUIDToAssetPath(assetGUIs[0]);
         }
+        else
+        {
+            pluginPath = Application.dataPath;
+            if (InEditor())
+            {
+                pluginPath += separator + ros2ForUnityAssetFolderName;
+            }
+        }
+
         return pluginPath; 
     }
 


### PR DESCRIPTION
Seems to fix #86 

But I am not entirely sure what happens here after a build and publish?

And the asset manager should be used for each resource directly, instead of using to determine the root path?