### PR TITLE
Add jazzy as supported distribution

### DIFF
--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -203,7 +203,7 @@ internal class ROS2ForUnity
     /// </summary>
     private void CheckROSSupport(string ros2Codename)
     {
-        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "rolling" };
+        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "jazzy", "rolling" };
         var supportedVersionsString = String.Join(", ", supportedVersions);
         if (string.IsNullOrEmpty(ros2Codename))
         {


### PR DESCRIPTION
In this PR, I will introduce a support for Jazzy distribution. (Iron is not tested but I think it will work)

There are changes:

- `CheckROSSupport` will now accept "jazzy"

I tested this PR on my Ubuntu 24.04 + Unity 2022.3.15f1 + ROS 2 Jazzy environment.