### PR TITLE
Support Jazzy distribution

### DIFF
--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -4,7 +4,7 @@ This readme contains information specific to Ubuntu 20.04/22.04. For general inf
 
 ## Building
 
-We assume that working directory is `~/ros2-for-unity` and we are using `ROS2 galactic` (replace with `foxy` or `humble` where applicable).
+We assume that working directory is `~/ros2-for-unity` and we are using `ROS2 galactic` (replace with `foxy`, `humble`, `jazzy` or `rolling` where applicable).
 
 ### Prerequisites
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -4,7 +4,7 @@ This readme contains information specific to Window 10. For general information,
 
 ## Building
 
-We assume that working directory is `C:\dev` and we are using `ROS2 galactic` (replace with `foxy` or `humble` where applicable).
+We assume that working directory is `C:\dev` and we are using `ROS2 galactic` (replace with `foxy`, `humble`, `jazzy` or `rolling` where applicable).
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -18,20 +18,24 @@ Advantages of this module include:
 ## Platforms
 
 Supported OSes:
+- Ubuntu 24.04 (bash)
 - Ubuntu 22.04 (bash)
 - Ubuntu 20.04 (bash)
-- Windows 10 (powershell)
-- Windows 11* (powershel)
+- Windows 10* (powershell)
+- Windows 11* (powershell)
 
 > \* ROS2 Galactic and Humble support only Windows 10 ([ROS 2 Windows system requirements](https://docs.ros.org/en/humble/Installation/Windows-Install-Binary.html#system-requirements)), but it is proven that it also works fine on Windows 11.
 
 
 Supported ROS2 distributions:
-- Galactic
+- Jazzy
 - Humble
+- Galactic
+- Foxy
 
 Supported Unity3d:
 - 2020+
+- 6000+
 
 Older versions of Unity3d may work, but the editor executable most probably won't be detected properly by deployment script. This would require user confirmation for using unsupported version.
 

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -4,7 +4,7 @@ SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 
 if [ -z "${ROS_DISTRO}" ]; then
-    echo "Can't detect ROS2 version. Source your ros2 distro first. Foxy and Galactic are supported"
+    echo "Can't detect ROS2 version. Source your ros2 distro first. Foxy, Galactic, Humble, Jazzy are supported"
     exit 1
 fi
 

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -2,4 +2,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/RobotecAI/ros2cs.git
-    version: 1.3.0
+    version: feature/jazzy-support

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -203,7 +203,7 @@ internal class ROS2ForUnity
     /// </summary>
     private void CheckROSSupport(string ros2Codename)
     {
-        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "rolling" };
+        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "jazzy", "rolling" };
         var supportedVersionsString = String.Join(", ", supportedVersions);
         if (string.IsNullOrEmpty(ros2Codename))
         {


### PR DESCRIPTION
Reminder: update `version: feature/jazzy-support` after merge of https://github.com/RobotecAI/ros2cs/pull/71
Based on https://github.com/RobotecAI/ros2-for-unity/pull/125