### PR TITLE
Fix Lyrical standalone environment setup and ros2cs pin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh text eol=lf
+*.py text eol=lf
 docker/Dockerfile text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Enforced LF endings for scripts and Python tooling that run in Unix-like environments.
+
 *.sh text eol=lf
 *.py text eol=lf
 docker/Dockerfile text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+docker/Dockerfile text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Ignored the local .tmp workspace scratch directory.
+#
 install
 log
 build
+.tmp
 .idea
 src/ros2cs
 **/metadata*.xml

--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -2,9 +2,11 @@
 
 This readme contains information specific to Ubuntu 20.04/22.04. For general information, please see [README.md](README.md)
 
+> Current status: these Ubuntu instructions are retained as legacy guidance. This Jazzy maintenance line has not recently revalidated Ubuntu 20.04/22.04/24.04. Treat the commands below as a starting point until a fresh Ubuntu build/test record is added.
+
 ## Building
 
-We assume that working directory is `~/ros2-for-unity` and we are using `ROS2 galactic` (replace with `foxy`, `humble`, `jazzy` or `rolling` where applicable).
+We assume that working directory is `~/ros2-for-unity` and we are using a sourced ROS 2 installation. Older examples mention Galactic/Foxy; the current active maintenance target is Jazzy.
 
 ### Prerequisites
 
@@ -14,12 +16,12 @@ Start with installation of dependencies. Make sure to complete each step of `ros
 
 * Clone this project.
     ```bash
-    git clone git@github.com:RobotecAI/ros2-for-unity.git ~/ros2-for-unity
+    git clone git@github.com:JianbinLiu-CFLab/ros2-for-unity.git ~/ros2-for-unity
     ```
 * You need to source your ROS2 installation before you proceed, for each new open terminal. It is convenient to include this command in your `~/.profile` file.
     ```bash
-    # galactic
-    . /opt/ros/galactic/setup.bash
+    # jazzy
+    . /opt/ros/jazzy/setup.bash
     ```
 * Enter `Ros2ForUnity` working directory.
     ```bash
@@ -50,7 +52,7 @@ Start with installation of dependencies. Make sure to complete each step of `ros
 ## OS-Specific usage remarks
 
 You can run Unity Editor or App executable from GUI (clicking) or from terminal as long as ROS2 is sourced in your environment.
-The best way to ensure that system-wide is to add `source /opt/ros/foxy/setup.bash` to your `~/.profile` file.
+The best way to ensure that system-wide is to add `source /opt/ros/jazzy/setup.bash` to your `~/.profile` file.
 Note that you need to re-log for changes in `~/.profile` to take place.
 Running Unity Editor through Unity Hub is also supported.
 

--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -3,6 +3,8 @@
 This readme contains information specific to Ubuntu 20.04/22.04. For general information, please see [README.md](README.md)
 
 > Current status: these Ubuntu instructions are retained as legacy guidance. This Jazzy maintenance line has not recently revalidated Ubuntu 20.04/22.04/24.04. Treat the commands below as a starting point until a fresh Ubuntu build/test record is added.
+>
+> The current Build GREEN / Unity Load GREEN evidence is Windows-native only. Do not infer Ubuntu support from the Windows Jazzy artifact or Unity Load smoke result.
 
 ## Building
 

--- a/README-UBUNTU.md
+++ b/README-UBUNTU.md
@@ -4,7 +4,7 @@ This readme contains information specific to Ubuntu 20.04/22.04. For general inf
 
 ## Building
 
-We assume that working directory is `~/ros2-for-unity` and we are using `ROS2 galactic` (replace with `foxy` or `humble` where applicable).
+We assume that working directory is `~/ros2-for-unity` and we are using `ROS2 galactic` (replace with `foxy`, `humble`, `jazzy` or `rolling` where applicable).
 
 ### Prerequisites
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -13,20 +13,20 @@ OS:        Windows 10 LTSC
 ROS 2:     Jazzy
 RMW:       rmw_fastrtps_cpp
 Unity:     6000.3.14f1
-R2FU:      d671f6a
-ros2cs:    d032edb
+R2FU:      v0.5.0-jazzy-win64-preview.1
+ros2cs:    v0.5.0-jazzy-preview.1
 Artifact:  Ros2ForUnity_jazzy_standalone_windows_x86_64.zip
-Release:   v0.2.0-jazzy-win64-preview.1
-SHA256:    497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82
+Release:   v0.5.0-jazzy-win64-preview.1
+SHA256:    see the release .sha256.txt asset
 ```
 
 Current source release after the latest cleanup fixes:
 
 ```text
-R2FU:      v0.4.0-jazzy-win64-preview.1
-ros2cs:    v0.4.0-jazzy-preview.1
-Release:   v0.4.0-jazzy-win64-preview.1
-Artifact:  not uploaded yet; regenerate the standalone zip before attaching release assets
+R2FU:      v0.5.0-jazzy-win64-preview.1
+ros2cs:    v0.5.0-jazzy-preview.1
+Release:   v0.5.0-jazzy-win64-preview.1
+Artifact:  uploaded with matching .sha256.txt and .manifest.json release assets
 ```
 
 Validated gates:
@@ -37,7 +37,7 @@ Validated gates:
 
 Not yet validated by this snapshot:
 
-- Unity Load smoke for the next regenerated `v0.4.0` artifact.
+- Unity Load smoke for the regenerated `v0.5.0` artifact.
 - Runtime pub/sub or service/client smoke.
 - ROS graph discovery stability.
 - Sensor runtime behavior in a real scene.
@@ -95,7 +95,7 @@ It is necessary to complete the `ros2cs` Windows prerequisites for the same bran
     ```
   * You can build with `-clean_install` to make sure your installation directory is cleaned before deploying.
   * Build scripts print a phase timing summary covering metadata generation, ros2cs build, Unity asset staging, plugin deploy, and metadata copy.
-  * Use `-quiet` to reduce live colcon terminal output while keeping logs under the configured colcon log base. Use `-verbose` to preserve the chatty `console_direct+` output.
+  * Use `-quiet` to reduce live colcon terminal output while keeping logs under the configured colcon log base. Use `-console_direct` to preserve the chatty `console_direct+` output.
   * Windows standalone deployment validates required managed and native files after copy, including `ros2cs_common.dll`, `ros2cs_core.dll`, `rcl.dll`, and `rmw_implementation.dll`.
 * Unity Asset is ready to import into your Unity project. You can find it in `install/asset/` directory.
 * (optionally) To create `.unitypackage` in `install/unity_package`

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -20,6 +20,15 @@ Release:   v0.2.0-jazzy-win64-preview.1
 SHA256:    497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82
 ```
 
+Current source release after the latest cleanup fixes:
+
+```text
+R2FU:      153882f
+ros2cs:    bbd5017
+Release:   v0.3.0-jazzy-win64-preview.1
+Artifact:  not uploaded yet; regenerate the standalone zip before attaching release assets
+```
+
 Validated gates:
 
 - Windows-native standalone build through `build.ps1`.
@@ -28,7 +37,7 @@ Validated gates:
 
 Not yet validated by this snapshot:
 
-- Unity Load smoke for the refreshed `v0.2.0` artifact.
+- Unity Load smoke for the next regenerated `v0.3.0` artifact.
 - Runtime pub/sub or service/client smoke.
 - ROS graph discovery stability.
 - Sensor runtime behavior in a real scene.

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -4,6 +4,35 @@ This readme contains information specific to Windows. For general information, p
 
 Current local maintenance evidence targets Windows 10 LTSC + ROS 2 Jazzy. Windows 11 is expected to use the same toolchain, but should be verified separately before making release claims.
 
+## Current Windows validation snapshot
+
+The current local validation snapshot is:
+
+```text
+OS:        Windows 10 LTSC
+ROS 2:     Jazzy
+RMW:       rmw_fastrtps_cpp
+Unity:     6000.3.14f1
+R2FU:      a92a1a6
+ros2cs:    65db989
+Artifact:  Ros2ForUnity_jazzy_standalone_windows_x86_64.zip
+SHA256:    22baf2b624b0fb171efc94b403876491a66e57b39b6f747a3c2e30644ce32188
+```
+
+Validated gates:
+
+- Windows-native standalone build through `build.ps1`.
+- Standalone artifact packaging.
+- Unity Load smoke in a fresh Unity project.
+
+Not yet validated by this snapshot:
+
+- Runtime pub/sub or service/client smoke.
+- ROS graph discovery stability.
+- Sensor runtime behavior in a real scene.
+- Unity Player export.
+- Windows 11.
+
 ## Current toolchain policy
 
 - Use ROS 2 Jazzy through the maintained environment wrapper when running ROS/colcon commands in this workspace.
@@ -60,6 +89,37 @@ It is necessary to complete the `ros2cs` Windows prerequisites for the same bran
   create_unity_package.ps1
   ```
   > *NOTE* Please provide path to your Unity executable when prompted. Unity license is required. In case your Unity license has expired, the `create_unity_package.ps1` won't throw any errors but `Ros2ForUnity.unitypackage` won't be generated too.
+
+## Unity Load smoke
+
+For the local maintenance workspace, the reusable Unity Load smoke project is:
+
+```text
+D:\ros2unity\R2FUUnityLoadSmoke
+```
+
+It is intentionally outside this git repository. It validates import/compile/native-load/`ROS2UnityCore` initialization only. It does not validate runtime pub/sub, graph discovery, sensors, Player export, or Product GREEN.
+
+Run it with a standalone-clean environment:
+
+```powershell
+$unity = 'C:\Program Files\Unity\Hub\Editor\6000.3.14f1\Editor\Unity.exe'
+$project = 'D:\ros2unity\R2FUUnityLoadSmoke'
+$log = 'D:\ros2unity\logs\r2fu-unity-load-smoke.log'
+$env:ROS_DISTRO = $null
+$env:ROS_VERSION = $null
+$env:ROS_PYTHON_VERSION = $null
+$env:AMENT_PREFIX_PATH = $null
+$env:COLCON_PREFIX_PATH = $null
+$env:RMW_IMPLEMENTATION = $null
+& $unity -projectPath $project -batchmode -nographics -quit -executeMethod R2FUUnityLoadSmoke.Run -logFile $log
+```
+
+Pass marker:
+
+```text
+R2FU_UNITY_LOAD_SMOKE_PASS
+```
 
 ## Build troubleshooting
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -13,20 +13,22 @@ OS:        Windows 10 LTSC
 ROS 2:     Jazzy
 RMW:       rmw_fastrtps_cpp
 Unity:     6000.3.14f1
-R2FU:      a92a1a6
-ros2cs:    65db989
+R2FU:      d671f6a
+ros2cs:    d032edb
 Artifact:  Ros2ForUnity_jazzy_standalone_windows_x86_64.zip
-SHA256:    22baf2b624b0fb171efc94b403876491a66e57b39b6f747a3c2e30644ce32188
+Release:   v0.2.0-jazzy-win64-preview.1
+SHA256:    497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82
 ```
 
 Validated gates:
 
 - Windows-native standalone build through `build.ps1`.
 - Standalone artifact packaging.
-- Unity Load smoke in a fresh Unity project.
+- `ros2cs_tests`: 77 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet validated by this snapshot:
 
+- Unity Load smoke for the refreshed `v0.2.0` artifact.
 - Runtime pub/sub or service/client smoke.
 - ROS graph discovery stability.
 - Sensor runtime behavior in a real scene.

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -60,7 +60,7 @@ Do not run `colcon build` directly against this repository's `src` directory whe
 
 ### Prerequisites
 
-It is necessary to complete the `ros2cs` Windows prerequisites for the same branch/fork used by this repository. For this maintenance line, `ros2cs.repos` points to the maintained `JianbinLiu-CFLab/ros2cs` `main` branch.
+It is necessary to complete the `ros2cs` Windows prerequisites for the same branch/fork used by this repository. For this maintenance line, `ros2cs.repos` points to the maintained `JianbinLiu-CFLab/ros2cs` preview tag recorded in that file. The `main` branch remains the active integration line, but tagged public builds should use pinned inputs.
 
 ### Steps
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -23,9 +23,9 @@ SHA256:    497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82
 Current source release after the latest cleanup fixes:
 
 ```text
-R2FU:      153882f
-ros2cs:    bbd5017
-Release:   v0.3.0-jazzy-win64-preview.1
+R2FU:      v0.4.0-jazzy-win64-preview.1
+ros2cs:    v0.4.0-jazzy-preview.1
+Release:   v0.4.0-jazzy-win64-preview.1
 Artifact:  not uploaded yet; regenerate the standalone zip before attaching release assets
 ```
 
@@ -33,11 +33,11 @@ Validated gates:
 
 - Windows-native standalone build through `build.ps1`.
 - Standalone artifact packaging.
-- `ros2cs_tests`: 77 NUnit tests passed, 0 failed, 0 skipped.
+- `ros2cs_tests`: 82 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet validated by this snapshot:
 
-- Unity Load smoke for the next regenerated `v0.3.0` artifact.
+- Unity Load smoke for the next regenerated `v0.4.0` artifact.
 - Runtime pub/sub or service/client smoke.
 - ROS graph discovery stability.
 - Sensor runtime behavior in a real scene.

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -94,6 +94,9 @@ It is necessary to complete the `ros2cs` Windows prerequisites for the same bran
     ./build.ps1
     ```
   * You can build with `-clean_install` to make sure your installation directory is cleaned before deploying.
+  * Build scripts print a phase timing summary covering metadata generation, ros2cs build, Unity asset staging, plugin deploy, and metadata copy.
+  * Use `-quiet` to reduce live colcon terminal output while keeping logs under the configured colcon log base. Use `-verbose` to preserve the chatty `console_direct+` output.
+  * Windows standalone deployment validates required managed and native files after copy, including `ros2cs_common.dll`, `ros2cs_core.dll`, `rcl.dll`, and `rmw_implementation.dll`.
 * Unity Asset is ready to import into your Unity project. You can find it in `install/asset/` directory.
 * (optionally) To create `.unitypackage` in `install/unity_package`
   ```powershell
@@ -133,6 +136,8 @@ R2FU_UNITY_LOAD_SMOKE_PASS
 ```
 
 ## Build troubleshooting
+
+- If a standalone build is unexpectedly slow during native DLL copy or artifact staging, check antivirus/Defender real-time scanning first. This repository does not change Defender policy automatically; any exclusions should be a deliberate local or CI-machine decision.
 
 - If you see one of the following errors:
 ><script_name> is not digitally signed

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -4,7 +4,7 @@ This readme contains information specific to Window 10. For general information,
 
 ## Building
 
-We assume that working directory is `C:\dev` and we are using `ROS2 galactic` (replace with `foxy` or `humble` where applicable).
+We assume that working directory is `C:\dev` and we are using `ROS2 galactic` (replace with `foxy`, `humble`, `jazzy` or `rolling` where applicable).
 
 ### Prerequisites
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -54,13 +54,13 @@ Not yet validated by this snapshot:
 
 ## Building
 
-The historical instructions below assume `C:\dev` and older ROS 2 layouts. For this fork's Jazzy maintenance line, prefer the repository-local scripts and the short-path build bases documented under `D:\ros2unity\plan`.
+The historical instructions below assume `C:\dev` and older ROS 2 layouts. For this fork's Jazzy maintenance line, prefer the repository-local scripts. The Windows build wrapper uses short build/log roots by default; override them with `R2FU_ROS2CS_BUILD_BASE` and `R2FU_ROS2CS_LOG_BASE` when you need explicit paths.
 
 Do not run `colcon build` directly against this repository's `src` directory when `src\ros2cs` is a junction to a canonical ros2cs checkout. On Windows, Python packages such as `sensor_msgs_py` can compute junction-relative `egg_base` paths incorrectly and fail even though the canonical ros2cs workspace is buildable. Use `build.ps1`, which resolves the canonical ros2cs checkout and builds from that source path.
 
 ### Prerequisites
 
-It is necessary to complete the `ros2cs` Windows prerequisites for the same branch/fork used by this repository. For this maintenance line, `ros2cs.repos` points to the maintained `JianbinLiu-CFLab/ros2cs` preview tag recorded in that file. The `main` branch remains the active integration line, but tagged public builds should use pinned inputs.
+It is necessary to complete the `ros2cs` Windows prerequisites for the same branch/fork used by this repository. For this maintenance line, `ros2cs.repos` points to the maintained `JianbinLiu-CFLab/ros2cs` preview commit hash recorded in that file. The `main` branch remains the active integration line, but public builds should use pinned inputs.
 
 ### Steps
 

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -16,6 +16,8 @@ Current local maintenance evidence targets Windows 10 LTSC + ROS 2 Jazzy. Window
 
 The historical instructions below assume `C:\dev` and older ROS 2 layouts. For this fork's Jazzy maintenance line, prefer the repository-local scripts and the short-path build bases documented under `D:\ros2unity\plan`.
 
+Do not run `colcon build` directly against this repository's `src` directory when `src\ros2cs` is a junction to a canonical ros2cs checkout. On Windows, Python packages such as `sensor_msgs_py` can compute junction-relative `egg_base` paths incorrectly and fail even though the canonical ros2cs workspace is buildable. Use `build.ps1`, which resolves the canonical ros2cs checkout and builds from that source path.
+
 ### Prerequisites
 
 It is necessary to complete the `ros2cs` Windows prerequisites for the same branch/fork used by this repository. For this maintenance line, `ros2cs.repos` points to the maintained `JianbinLiu-CFLab/ros2cs` `main` branch.

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -13,19 +13,19 @@ OS:        Windows 10 LTSC
 ROS 2:     Jazzy
 RMW:       rmw_fastrtps_cpp
 Unity:     6000.3.14f1
-R2FU:      v0.5.0-jazzy-win64-preview.1
-ros2cs:    v0.5.0-jazzy-preview.1
+R2FU:      v0.6.0-jazzy-win64-preview.1
+ros2cs:    v0.6.0-jazzy-preview.1
 Artifact:  Ros2ForUnity_jazzy_standalone_windows_x86_64.zip
-Release:   v0.5.0-jazzy-win64-preview.1
+Release:   v0.6.0-jazzy-win64-preview.1
 SHA256:    see the release .sha256.txt asset
 ```
 
 Current source release after the latest cleanup fixes:
 
 ```text
-R2FU:      v0.5.0-jazzy-win64-preview.1
-ros2cs:    v0.5.0-jazzy-preview.1
-Release:   v0.5.0-jazzy-win64-preview.1
+R2FU:      v0.6.0-jazzy-win64-preview.1
+ros2cs:    v0.6.0-jazzy-preview.1
+Release:   v0.6.0-jazzy-win64-preview.1
 Artifact:  uploaded with matching .sha256.txt and .manifest.json release assets
 ```
 
@@ -37,7 +37,7 @@ Validated gates:
 
 Not yet validated by this snapshot:
 
-- Unity Load smoke for the regenerated `v0.5.0` artifact.
+- Unity Load smoke for the regenerated `v0.6.0` artifact.
 - Runtime pub/sub or service/client smoke.
 - ROS graph discovery stability.
 - Sensor runtime behavior in a real scene.

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -1,27 +1,37 @@
-# ROS2 For Unity - Windows 10
+# ROS2 For Unity - Windows 10/11
 
-This readme contains information specific to Window 10. For general information, please see [README.md](README.md).
+This readme contains information specific to Windows. For general information, please see [README.md](README.md).
+
+Current local maintenance evidence targets Windows 10 LTSC + ROS 2 Jazzy. Windows 11 is expected to use the same toolchain, but should be verified separately before making release claims.
+
+## Current toolchain policy
+
+- Use ROS 2 Jazzy through the maintained environment wrapper when running ROS/colcon commands in this workspace.
+- Use Ninja as the Windows generator for Jazzy builds. This is the preferred ROS 2 Windows build shape and avoids unsupported Visual Studio generator detection with newer Visual Studio shells.
+- If Visual Studio 2026 / `VSCMD_VER=18.*` is present, do not rely on colcon auto-detecting a Visual Studio generator. Pass `-G Ninja` or set the generator through the wrapper/build orchestrator.
+- If CMake finds the wrong Python, pass `"-DPython3_EXECUTABLE:FILEPATH=<jazzy-pixi-python>"` as one quoted `-D` argument.
+- ROS 2 Jazzy + FastRTPS may print `ERRORFailed to load RTI Connext DDS Micro` while probing installed RMW plugins. Treat it as non-blocking only when `RMW_IMPLEMENTATION=rmw_fastrtps_cpp`, build/test exit codes are 0, and the message appears only in ROS interface package stderr.
 
 ## Building
 
-We assume that working directory is `C:\dev` and we are using `ROS2 galactic` (replace with `foxy`, `humble`, `jazzy` or `rolling` where applicable).
+The historical instructions below assume `C:\dev` and older ROS 2 layouts. For this fork's Jazzy maintenance line, prefer the repository-local scripts and the short-path build bases documented under `D:\ros2unity\plan`.
 
 ### Prerequisites
 
-It is necessary to complete all the steps for `ros2cs` [Prerequisites](https://github.com/RobotecAI/ros2cs/blob/master/README-WINDOWS.md#prerequisites) and consider [Important notices](https://github.com/RobotecAI/ros2cs/blob/master/README-WINDOWS.md#important-notices) sections.
+It is necessary to complete the `ros2cs` Windows prerequisites for the same branch/fork used by this repository. For this maintenance line, `ros2cs.repos` points to the maintained `JianbinLiu-CFLab/ros2cs` `main` branch.
 
 ### Steps
 
 * Make sure [long paths on Windows are enabled](https://github.com/RobotecAI/ros2cs/blob/master/README-WINDOWS.md#important-notices)
-* Make sure you open [`Developer PowerShell for VS` with administrator privileges](https://github.com/RobotecAI/ros2cs/blob/master/README-WINDOWS.md#important-notices)
-* For `ros2 galactic` distribution, it is best to [create a `C:\ci\ws\install\include` directory](https://github.com/RobotecAI/ros2cs/blob/master/README-WINDOWS.md#important-notices)
+* Make sure you open a Visual Studio Developer PowerShell compatible with the installed ROS 2 Jazzy toolchain.
+* Prefer Ninja generator builds on Windows. Newer Visual Studio generator names may not be supported by the Jazzy-pinned CMake/colcon stack.
 * Clone this project.
   ```powershell
-  git clone git@github.com:RobotecAI/ros2-for-unity.git C:\dev\ros2-for-unity
+  git clone git@github.com:JianbinLiu-CFLab/ros2-for-unity.git C:\dev\ros2-for-unity
   ```
-* Source your ROS2 installation (`C:\dev\ros2_foxy\local_setup.ps1`) in the terminal before you proceed.
+* Source your ROS2 installation in the terminal before you proceed.
   ```
-  C:\dev\ros2_foxy\local_setup.ps1
+  C:\dev\ros2_jazzy\local_setup.ps1
   ```
 * Enter `Ros2ForUnity` working directory.
     ```powershell

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ This fork consumes the maintained ros2cs fork through `ros2cs.repos`:
 
 ```text
 https://github.com/JianbinLiu-CFLab/ros2cs.git
-version: main
+version: v0.3.1-jazzy-preview.1
 ```
+
+The `main` branch remains the active integration line, while public build inputs are pinned to preview tags for reproducibility.
 
 The upstream RobotecAI repositories remain the original source and licensing history, but they are not the active integration target for this Jazzy/R2FU maintenance line. Upstream changes should be reviewed and cherry-picked deliberately.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This fork consumes the maintained ros2cs fork through `ros2cs.repos`:
 
 ```text
 https://github.com/JianbinLiu-CFLab/ros2cs.git
-version: v0.3.1-jazzy-preview.1
+version: v0.4.0-jazzy-preview.1
 ```
 
 The `main` branch remains the active integration line, while public build inputs are pinned to preview tags for reproducibility.
@@ -37,14 +37,14 @@ Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy.
 Verified on the current maintenance line:
 
 - Build GREEN: Windows-native Jazzy standalone asset build through `build.ps1`, using the canonical `ros2cs` workspace and documented short-path Windows layout.
-- Latest source release: [`v0.3.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.3.0-jazzy-win64-preview.1).
-- Latest packaged Windows artifact: still [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1) until the standalone zip is regenerated from the `v0.3.0` source line.
+- Latest source release: [`v0.4.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.4.0-jazzy-win64-preview.1).
+- Latest packaged Windows artifact: still [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1) until the standalone zip is regenerated from the `v0.4.0` source line.
 - Current `v0.2.0` artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82`.
-- Managed/native regression signal: `ros2cs_tests` reports 77 NUnit tests passed, 0 failed, 0 skipped.
+- Managed/native regression signal: `ros2cs_tests` reports 82 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet claimed:
 
-- Unity Load GREEN for the next `v0.3.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be regenerated, re-imported, and rechecked before upgrading the claim.
+- Unity Load GREEN for the next `v0.4.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be regenerated, re-imported, and rechecked before upgrading the claim.
 - Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation on the refreshed artifact.
 - Product GREEN: Player export, release signing, deterministic artifact packaging, and broader scenario validation are still later gates.
 
@@ -82,7 +82,7 @@ RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/relea
 
 For this fork's Jazzy Windows maintenance line, use the JianbinLiu-CFLab releases:
 
-- latest source release: [`v0.3.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.3.0-jazzy-win64-preview.1)
+- latest source release: [`v0.4.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.4.0-jazzy-win64-preview.1)
 - latest packaged Windows artifact: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1)
 - previous: [`v0.1.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.1.0-jazzy-win64-preview.1)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This fork consumes the maintained ros2cs fork through `ros2cs.repos`:
 
 ```text
 https://github.com/JianbinLiu-CFLab/ros2cs.git
-version: 6778163f16d03457b7925d1e5a6e97f430604c9b
+version: e0c06c3e050c1c6d50d4cae88aaa60cde04f0ed3
 ```
 
 The `main` branch remains the active integration line, while public build inputs are pinned to verified preview commit hashes for reproducibility.
@@ -37,14 +37,14 @@ Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy.
 Verified on the current maintenance line:
 
 - Build GREEN: Windows-native Jazzy standalone asset build through `build.ps1`, using the canonical `ros2cs` workspace and documented short-path Windows layout.
-- Latest source release: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1).
-- Latest packaged Windows artifact: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1).
-- Current `v0.5.0` artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip`. The release publishes a matching `.sha256.txt` and `.manifest.json` next to the zip.
+- Latest source release: [`v0.6.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.6.0-jazzy-win64-preview.1).
+- Latest packaged Windows artifact: [`v0.6.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.6.0-jazzy-win64-preview.1).
+- Current `v0.6.0` artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip`. The release publishes a matching `.sha256.txt` and `.manifest.json` next to the zip.
 - Managed/native regression signal: `ros2cs_tests` reports 82 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet claimed:
 
-- Unity Load GREEN for the `v0.5.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be re-imported and rechecked before upgrading the claim.
+- Unity Load GREEN for the `v0.6.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be re-imported and rechecked before upgrading the claim.
 - Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation on the refreshed artifact.
 - Product GREEN: Player export, release signing, deterministic artifact packaging, and broader scenario validation are still later gates.
 
@@ -82,9 +82,9 @@ RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/relea
 
 For this fork's Jazzy Windows maintenance line, use the JianbinLiu-CFLab releases:
 
-- latest source release: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1)
-- latest packaged Windows artifact: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1)
-- previous: [`v0.4.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.4.0-jazzy-win64-preview.1)
+- latest source release: [`v0.6.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.6.0-jazzy-win64-preview.1)
+- latest packaged Windows artifact: [`v0.6.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.6.0-jazzy-win64-preview.1)
+- previous: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1)
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This fork consumes the maintained ros2cs fork through `ros2cs.repos`:
 
 ```text
 https://github.com/JianbinLiu-CFLab/ros2cs.git
-version: v0.5.0-jazzy-preview.1
+version: 6778163f16d03457b7925d1e5a6e97f430604c9b
 ```
 
-The `main` branch remains the active integration line, while public build inputs are pinned to preview tags for reproducibility.
+The `main` branch remains the active integration line, while public build inputs are pinned to verified preview commit hashes for reproducibility.
 
 The upstream RobotecAI repositories remain the original source and licensing history, but they are not the active integration target for this Jazzy/R2FU maintenance line. Upstream changes should be reviewed and cherry-picked deliberately.
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy.
 Verified on the current maintenance line:
 
 - Build GREEN: Windows-native Jazzy standalone asset build through `build.ps1`, using the canonical `ros2cs` workspace and documented short-path Windows layout.
-- Latest release: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1).
-- Artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82`.
+- Latest source release: [`v0.3.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.3.0-jazzy-win64-preview.1).
+- Latest packaged Windows artifact: still [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1) until the standalone zip is regenerated from the `v0.3.0` source line.
+- Current `v0.2.0` artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82`.
 - Managed/native regression signal: `ros2cs_tests` reports 77 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet claimed:
 
-- Unity Load GREEN for the latest `v0.2.0` artifact: the prior Unity Load route is known, but this refreshed runtime artifact should be re-imported and rechecked before upgrading the claim.
+- Unity Load GREEN for the next `v0.3.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be regenerated, re-imported, and rechecked before upgrading the claim.
 - Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation on the refreshed artifact.
 - Product GREEN: Player export, release signing, deterministic artifact packaging, and broader scenario validation are still later gates.
 
@@ -79,7 +80,8 @@ RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/relea
 
 For this fork's Jazzy Windows maintenance line, use the JianbinLiu-CFLab releases:
 
-- latest: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1)
+- latest source release: [`v0.3.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.3.0-jazzy-win64-preview.1)
+- latest packaged Windows artifact: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1)
 - previous: [`v0.1.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.1.0-jazzy-win64-preview.1)
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -28,23 +28,24 @@ version: main
 
 The upstream RobotecAI repositories remain the original source and licensing history, but they are not the active integration target for this Jazzy/R2FU maintenance line. Upstream changes should be reviewed and cherry-picked deliberately.
 
+## Current verification status
+
+Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy. The canonical `ros2cs` dependency workspace builds and runs `ros2cs_tests` under the documented short-path Windows layout. R2FU Unity import, Player packaging, and runtime smoke validation are still separate validation stages and should not be inferred from the `ros2cs` workspace result alone.
+
+Core `ros2cs` assemblies and generated message assemblies stay on `netstandard2.0`; `ros2cs` tests and examples use modern .NET where applicable. R2FU Unity scripts remain Unity/C# runtime scripts and are validated through Unity-side stages.
+
 ## Platforms
 
-Supported OSes:
-- Ubuntu 24.04 (bash)
-- Ubuntu 22.04 (bash)
-- Ubuntu 20.04 (bash)
-- Windows 10* (powershell)
-- Windows 11* (powershell)
-
-> \* ROS2 Galactic and Humble support only Windows 10 ([ROS 2 Windows system requirements](https://docs.ros.org/en/humble/Installation/Windows-Install-Binary.html#system-requirements)), but it is proven that it also works fine on Windows 11.
+Maintained/validated OS status:
+- Windows 10 LTSC + ROS 2 Jazzy: current active maintenance target.
+- Windows 11 + ROS 2 Jazzy: expected to work through the same Windows toolchain, but should be verified separately before release claims.
+- Ubuntu 20.04/22.04/24.04: legacy instructions are retained, but this Jazzy maintenance line has not recently revalidated Ubuntu.
 
 
-Supported ROS2 distributions:
-- Jazzy
-- Humble
-- Galactic
-- Foxy
+ROS 2 distribution status:
+- Jazzy: current active maintenance target.
+- Humble: expected compatibility target, not the current evidence baseline.
+- Foxy/Galactic/Rolling: historical or experimental; do not treat as validated for this fork without a fresh build/test record.
 
 Supported Unity3d:
 - 2020+
@@ -59,9 +60,7 @@ This asset can be prepared in two flavours:
 
 ## Releases
 
-The best way to start quickly is to use our releases.
-
-You can download pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/releases) of the Asset that support both platforms and specific ros2 and Unity3D versions.
+RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/releases) remain useful historical artifacts for their original supported ROS 2 and Unity versions. For this fork's Jazzy maintenance line, build from this repository until fork-specific releases are published.
 
 ## Building
 
@@ -84,7 +83,7 @@ Custom messages can be included in the build by either:
 1. Open or create Unity project.
 1. Import asset into project:
     1. copy `install/asset/Ros2ForUnity` into your project `Assets` folder, or
-    1. if you have deployed an `.unitypackage` - import it in Unity Editor by selecting `Import Package` → `Custom Package`
+    1. if you have deployed an `.unitypackage` - import it in Unity Editor by selecting `Import Package` -> `Custom Package`
 
 ## Usage
 
@@ -190,8 +189,12 @@ otherwise
 1. You can also make an async call:
     ```c#
     Task<example_interfaces.srv.AddTwoInts_Response> asyncTask = addTwoIntsClient.CallAsync(request);
-    ...
-    asyncTask.ContinueWith((task) => { Debug.Log("Got answer " + task.Result.Sum); });
+    yield return new WaitUntil(() => asyncTask.IsCompleted);
+    if (asyncTask.IsFaulted) {
+        Debug.LogException(asyncTask.Exception);
+    } else if (!asyncTask.IsCanceled) {
+        Debug.Log("Got answer " + asyncTask.Result.Sum);
+    }
     ```
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,20 @@ The upstream RobotecAI repositories remain the original source and licensing his
 
 ## Current verification status
 
-Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy. The canonical `ros2cs` dependency workspace builds and runs `ros2cs_tests` under the documented short-path Windows layout. R2FU Unity import, Player packaging, and runtime smoke validation are still separate validation stages and should not be inferred from the `ros2cs` workspace result alone.
+Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy.
+
+Verified on the current maintenance line:
+
+- Build GREEN: Windows-native Jazzy standalone asset build through `build.ps1`, using the canonical `ros2cs` workspace and documented short-path Windows layout.
+- Artifact candidate: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `22baf2b624b0fb171efc94b403876491a66e57b39b6f747a3c2e30644ce32188`.
+- Unity Load GREEN: Unity `6000.3.14f1` imports the artifact in a fresh project, compiles scripts, loads key native dependencies, initializes `ROS2UnityCore`, and shuts down cleanly.
+
+Not yet claimed:
+
+- Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation.
+- Product GREEN: Player export, release signing, deterministic artifact packaging, and broader scenario validation are still later gates.
+
+Test coverage note: current R2FU validation intentionally uses `ros2cs_tests` as the managed/native binding regression signal. Full upstream ROS interface package test sweeps are not claimed here.
 
 Core `ros2cs` assemblies and generated message assemblies stay on `netstandard2.0`; `ros2cs` tests and examples use modern .NET where applicable. R2FU Unity scripts remain Unity/C# runtime scripts and are validated through Unity-side stages.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This fork consumes the maintained ros2cs fork through `ros2cs.repos`:
 
 ```text
 https://github.com/JianbinLiu-CFLab/ros2cs.git
-version: v0.4.0-jazzy-preview.1
+version: v0.5.0-jazzy-preview.1
 ```
 
 The `main` branch remains the active integration line, while public build inputs are pinned to preview tags for reproducibility.
@@ -37,14 +37,14 @@ Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy.
 Verified on the current maintenance line:
 
 - Build GREEN: Windows-native Jazzy standalone asset build through `build.ps1`, using the canonical `ros2cs` workspace and documented short-path Windows layout.
-- Latest source release: [`v0.4.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.4.0-jazzy-win64-preview.1).
-- Latest packaged Windows artifact: still [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1) until the standalone zip is regenerated from the `v0.4.0` source line.
-- Current `v0.2.0` artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82`.
+- Latest source release: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1).
+- Latest packaged Windows artifact: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1).
+- Current `v0.5.0` artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip`. The release publishes a matching `.sha256.txt` and `.manifest.json` next to the zip.
 - Managed/native regression signal: `ros2cs_tests` reports 82 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet claimed:
 
-- Unity Load GREEN for the next `v0.4.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be regenerated, re-imported, and rechecked before upgrading the claim.
+- Unity Load GREEN for the `v0.5.0` artifact: the prior Unity Load route is known, but the refreshed runtime artifact should be re-imported and rechecked before upgrading the claim.
 - Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation on the refreshed artifact.
 - Product GREEN: Player export, release signing, deterministic artifact packaging, and broader scenario validation are still later gates.
 
@@ -82,9 +82,9 @@ RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/relea
 
 For this fork's Jazzy Windows maintenance line, use the JianbinLiu-CFLab releases:
 
-- latest source release: [`v0.4.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.4.0-jazzy-win64-preview.1)
-- latest packaged Windows artifact: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1)
-- previous: [`v0.1.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.1.0-jazzy-win64-preview.1)
+- latest source release: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1)
+- latest packaged Windows artifact: [`v0.5.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.5.0-jazzy-win64-preview.1)
+- previous: [`v0.4.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.4.0-jazzy-win64-preview.1)
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -18,20 +18,24 @@ Advantages of this module include:
 ## Platforms
 
 Supported OSes:
+- Ubuntu 24.04 (bash)
 - Ubuntu 22.04 (bash)
 - Ubuntu 20.04 (bash)
-- Windows 10 (powershell)
-- Windows 11* (powershel)
+- Windows 10* (powershell)
+- Windows 11* (powershell)
 
 > \* ROS2 Galactic and Humble support only Windows 10 ([ROS 2 Windows system requirements](https://docs.ros.org/en/humble/Installation/Windows-Install-Binary.html#system-requirements)), but it is proven that it also works fine on Windows 11.
 
 
 Supported ROS2 distributions:
-- Galactic
+- Jazzy
 - Humble
+- Galactic
+- Foxy
 
 Supported Unity3d:
 - 2020+
+- 6000+
 
 Older versions of Unity3d may work, but the editor executable most probably won't be detected properly by deployment script. This would require user confirmation for using unsupported version.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Advantages of this module include:
 - Custom messages are generated automatically with build, using standard ROS2 way. It is straightforward to generate and use them without having to define `.cs` equivalents by hand.
 - The module is wrapped as a Unity asset.
 
+## Maintained integration line
+
+For the JianbinLiu-CFLab fork, `main` is the maintained integration line.
+
+This fork consumes the maintained ros2cs fork through `ros2cs.repos`:
+
+```text
+https://github.com/JianbinLiu-CFLab/ros2cs.git
+version: main
+```
+
+The upstream RobotecAI repositories remain the original source and licensing history, but they are not the active integration target for this Jazzy/R2FU maintenance line. Upstream changes should be reviewed and cherry-picked deliberately.
+
 ## Platforms
 
 Supported OSes:

--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ Current local maintenance evidence is centered on Windows 10 LTSC + ROS 2 Jazzy.
 Verified on the current maintenance line:
 
 - Build GREEN: Windows-native Jazzy standalone asset build through `build.ps1`, using the canonical `ros2cs` workspace and documented short-path Windows layout.
-- Artifact candidate: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `22baf2b624b0fb171efc94b403876491a66e57b39b6f747a3c2e30644ce32188`.
-- Unity Load GREEN: Unity `6000.3.14f1` imports the artifact in a fresh project, compiles scripts, loads key native dependencies, initializes `ROS2UnityCore`, and shuts down cleanly.
+- Latest release: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1).
+- Artifact: `Ros2ForUnity_jazzy_standalone_windows_x86_64.zip` with SHA256 `497a245edbaff247f4c428d4f131a8c1d93c5be2fc6d763cb1e4624586c67e82`.
+- Managed/native regression signal: `ros2cs_tests` reports 77 NUnit tests passed, 0 failed, 0 skipped.
 
 Not yet claimed:
 
-- Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation.
+- Unity Load GREEN for the latest `v0.2.0` artifact: the prior Unity Load route is known, but this refreshed runtime artifact should be re-imported and rechecked before upgrading the claim.
+- Runtime Smoke GREEN: runtime pub/sub, service/client, graph discovery, sensor scene behavior, and repeated Play/Stop still need dedicated Unity-side validation on the refreshed artifact.
 - Product GREEN: Player export, release signing, deterministic artifact packaging, and broader scenario validation are still later gates.
 
 Test coverage note: current R2FU validation intentionally uses `ros2cs_tests` as the managed/native binding regression signal. Full upstream ROS interface package test sweeps are not claimed here.
@@ -73,7 +75,12 @@ This asset can be prepared in two flavours:
 
 ## Releases
 
-RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/releases) remain useful historical artifacts for their original supported ROS 2 and Unity versions. For this fork's Jazzy maintenance line, build from this repository until fork-specific releases are published.
+RobotecAI pre-built [releases](https://github.com/RobotecAI/ros2-for-unity/releases) remain useful historical artifacts for their original supported ROS 2 and Unity versions.
+
+For this fork's Jazzy Windows maintenance line, use the JianbinLiu-CFLab releases:
+
+- latest: [`v0.2.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.2.0-jazzy-win64-preview.1)
+- previous: [`v0.1.0-jazzy-win64-preview.1`](https://github.com/JianbinLiu-CFLab/ros2-for-unity/releases/tag/v0.1.0-jazzy-win64-preview.1)
 
 ## Building
 

--- a/build.ps1
+++ b/build.ps1
@@ -34,7 +34,7 @@ Param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $script:TimingRows = New-Object System.Collections.Generic.List[object]
 $script:TotalStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
@@ -132,7 +132,7 @@ function Resolve-RequiredCommand {
 }
 
 try {
-    if(-Not (Test-Path -Path "$scriptPath\src\ros2cs")) {
+    if(-Not (Test-Path -LiteralPath "$scriptPath\src\ros2cs")) {
         throw "Pull repositories with 'pull_repositories.ps1' first."
     }
 
@@ -221,8 +221,11 @@ try {
     }
 
     Invoke-Timed "metadata copy" {
-        Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\Windows\x86_64\ -Force
-        Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\ -Force
+        $metadataSource = Join-Path -Path $scriptPath -ChildPath "src\Ros2ForUnity\metadata_ros2cs.xml"
+        $metadataWindowsDestination = Join-Path -Path $scriptPath -ChildPath "install\asset\Ros2ForUnity\Plugins\Windows\x86_64"
+        $metadataPluginDestination = Join-Path -Path $scriptPath -ChildPath "install\asset\Ros2ForUnity\Plugins"
+        Copy-Item -LiteralPath $metadataSource -Destination $metadataWindowsDestination -Force
+        Copy-Item -LiteralPath $metadataSource -Destination $metadataPluginDestination -Force
     }
 }
 finally {

--- a/build.ps1
+++ b/build.ps1
@@ -10,6 +10,10 @@
     Add ros2 binaries. Currently standalone flag is fixed to true, so there is no way to build without standalone libs. Parameter kept for future releases
 .PARAMETER clean_install
     Makes a clean installation. Removes install dir before deploying
+.PARAMETER quiet
+    Reduce live colcon console output. Full logs are still written under the configured colcon log base.
+.PARAMETER verbose
+    Preserve the chatty console_direct+ colcon output. This is the default for compatibility.
 
 Modifications Copyright (c) 2026 Jianbin Liu.
 
@@ -17,17 +21,92 @@ Modifications by Jianbin Liu:
 - Added strict/fail-fast behavior for Windows builds.
 - Routed ros2cs builds through the canonical ros2cs workspace with short build roots.
 - Preserved standalone asset deployment as the public Windows packaging path.
+- Added phase timing, quiet/verbose output control, and robocopy-based asset staging.
 #>
 Param (
     [Parameter(Mandatory=$false)][switch]$with_tests=$false,
     [Parameter(Mandatory=$false)][switch]$standalone=$false,
-    [Parameter(Mandatory=$false)][switch]$clean_install=$false
+    [Parameter(Mandatory=$false)][switch]$clean_install=$false,
+    [Parameter(Mandatory=$false)][switch]$quiet=$false,
+    [Parameter(Mandatory=$false)][switch]$verbose=$false
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+$script:TimingRows = New-Object System.Collections.Generic.List[object]
+$script:TotalStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+function Format-Duration {
+    param([Parameter(Mandatory=$true)][TimeSpan]$Elapsed)
+    return "{0:mm\:ss\.fff}" -f $Elapsed
+}
+
+function Invoke-Timed {
+    param(
+        [Parameter(Mandatory=$true)][string]$Name,
+        [Parameter(Mandatory=$true)][scriptblock]$Action
+    )
+
+    $watch = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        & $Action
+    }
+    finally {
+        $watch.Stop()
+        $script:TimingRows.Add([pscustomobject]@{
+            Phase = $Name
+            Elapsed = $watch.Elapsed
+        }) | Out-Null
+    }
+}
+
+function Write-TimingSummary {
+    if ($script:TotalStopwatch.IsRunning) {
+        $script:TotalStopwatch.Stop()
+    }
+
+    Write-Host ""
+    Write-Host "Ros2ForUnity build timing summary:" -ForegroundColor Cyan
+    foreach ($row in $script:TimingRows) {
+        Write-Host ("  {0,-28} {1}" -f $row.Phase, (Format-Duration $row.Elapsed))
+    }
+    Write-Host ("  {0,-28} {1}" -f "total", (Format-Duration $script:TotalStopwatch.Elapsed))
+}
+
+function Invoke-RobocopyMirror {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Destination
+    )
+
+    if (-not (Test-Path -LiteralPath $Source)) {
+        throw "robocopy source does not exist: $Source"
+    }
+
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    $robocopyArgs = @(
+        $Source,
+        $Destination,
+        "/MIR",
+        "/MT:8",
+        "/R:2",
+        "/W:1",
+        "/NP"
+    )
+    if ($quiet -and -not $verbose) {
+        $robocopyArgs += @("/NFL", "/NDL")
+    }
+
+    & robocopy @robocopyArgs
+    $robocopyExitCode = $LASTEXITCODE
+    # Robocopy uses 0-7 for success / informational outcomes.
+    if ($robocopyExitCode -gt 7) {
+        throw "robocopy failed from '$Source' to '$Destination' with exit code $robocopyExitCode"
+    }
+    $global:LASTEXITCODE = 0
+}
 
 function Get-DefaultWorkPath {
     param([Parameter(Mandatory=$true)][string]$Name)
@@ -52,74 +131,102 @@ function Resolve-RequiredCommand {
     }
 }
 
-if(-Not (Test-Path -Path "$scriptPath\src\ros2cs")) {
-    Write-Host "Pull repositories with 'pull_repositories.ps1' first." -ForegroundColor Red
-    exit 1
-}
-
-Write-Host "Building Ros2ForUnity asset..." -ForegroundColor Green
-$tests_switch = if ($with_tests) { 1 } else { 0 }
-$standalone_switch = if ($standalone) { 1 } else { 0 }
-
-if($clean_install) {
-    Write-Host "Cleaning install directory..." -ForegroundColor White
-    Remove-Item -Path "$scriptPath\install" -Force -Recurse -ErrorAction Ignore
-}
-
-if($standalone) {
-  & "python" "$scriptPath\src\scripts\metadata_generator.py" --standalone
-} else {
-  & "python" "$scriptPath\src\scripts\metadata_generator.py"
-}
-if ($LASTEXITCODE -ne 0) {
-    throw "metadata_generator.py failed with exit code $LASTEXITCODE"
-}
-
-# Resolve the junction target so colcon builds the canonical ros2cs workspace, not the R2FU src wrapper.
-$ros2csItem = Get-Item "$scriptPath\src\ros2cs" -Force
-$ros2csPath = if ($ros2csItem.Target -and $ros2csItem.Target.Count -gt 0) { $ros2csItem.Target[0] } else { $ros2csItem.FullName }
-$ros2csSourcePath = Join-Path -Path $ros2csPath -ChildPath "src"
-$ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
-# Keep generated ROS/MSVC object paths short while allowing CI or local scripts to override the roots.
-$ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { Get-DefaultWorkPath "r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
-$ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { Get-DefaultWorkPath "r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
-$pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) {
-    Resolve-RequiredCommand "python" "Run this script from a sourced ROS 2 Jazzy environment, or set COLCON_PYTHON_EXECUTABLE."
-} else { $Env:COLCON_PYTHON_EXECUTABLE }
-$colconExecutable = Resolve-RequiredCommand "colcon" "Run this script from a sourced ROS 2 Jazzy environment so colcon is on PATH."
-
-Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -ForegroundColor Green
-& $colconExecutable `
-    --log-base $ros2csLogBase `
-    build `
-    --base-paths $ros2csSourcePath `
-    --build-base $ros2csBuildBase `
-    --install-base $ros2csInstallPath `
-    --merge-install `
-    --event-handlers console_direct+ `
-    --cmake-args `
-    -G Ninja `
-    -DSTANDALONE_BUILD:int=$standalone_switch `
-    -DCMAKE_BUILD_TYPE=Release `
-    -DBUILD_TESTING:int=$tests_switch `
-    "-DPython3_EXECUTABLE:FILEPATH=$pythonExecutable" `
-    --no-warn-unused-cli
-if($LASTEXITCODE -eq 0) {
-    New-Item -ItemType Directory -Force -Path (Join-Path -Path $scriptPath -ChildPath "install\asset") | Out-Null
-    Copy-Item -Path $scriptPath\src\Ros2ForUnity -Destination $scriptPath\install\asset\ -Recurse -Force
-    
-    $pluginPath = Join-Path -Path $scriptPath -ChildPath "install\asset\Ros2ForUnity\Plugins"
-    Write-Host "Deploying build to $pluginPath" -ForegroundColor Green
-    & "$scriptPath\deploy_unity_plugins.ps1" $pluginPath $ros2csInstallPath
-    if ($LASTEXITCODE -ne 0) {
-        throw "deploy_unity_plugins.ps1 failed with exit code $LASTEXITCODE"
+try {
+    if(-Not (Test-Path -Path "$scriptPath\src\ros2cs")) {
+        throw "Pull repositories with 'pull_repositories.ps1' first."
     }
 
-    Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\Windows\x86_64\
-    Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\
-} else {
-    Write-Host "Ros2cs build failed!" -ForegroundColor Red
-    exit 1
+    Write-Host "Building Ros2ForUnity asset..." -ForegroundColor Green
+    $tests_switch = if ($with_tests) { 1 } else { 0 }
+    $standalone_switch = if ($standalone) { 1 } else { 0 }
+
+    if($clean_install) {
+        Invoke-Timed "clean install" {
+            Write-Host "Cleaning install directory..." -ForegroundColor White
+            Remove-Item -Path "$scriptPath\install" -Force -Recurse -ErrorAction Ignore
+        }
+    }
+
+    Invoke-Timed "metadata generation" {
+        if($standalone) {
+          & "python" "$scriptPath\src\scripts\metadata_generator.py" --standalone
+        } else {
+          & "python" "$scriptPath\src\scripts\metadata_generator.py"
+        }
+        if ($LASTEXITCODE -ne 0) {
+            throw "metadata_generator.py failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    # Resolve the junction target so colcon builds the canonical ros2cs workspace, not the R2FU src wrapper.
+    $ros2csItem = Get-Item "$scriptPath\src\ros2cs" -Force
+    $ros2csPath = if ($ros2csItem.Target -and $ros2csItem.Target.Count -gt 0) { $ros2csItem.Target[0] } else { $ros2csItem.FullName }
+    $ros2csSourcePath = Join-Path -Path $ros2csPath -ChildPath "src"
+    $ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
+    # Keep generated ROS/MSVC object paths short while allowing CI or local scripts to override the roots.
+    $ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { Get-DefaultWorkPath "r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
+    $ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { Get-DefaultWorkPath "r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
+    $pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) {
+        Resolve-RequiredCommand "python" "Run this script from a sourced ROS 2 Jazzy environment, or set COLCON_PYTHON_EXECUTABLE."
+    } else { $Env:COLCON_PYTHON_EXECUTABLE }
+    $colconExecutable = Resolve-RequiredCommand "colcon" "Run this script from a sourced ROS 2 Jazzy environment so colcon is on PATH."
+
+    $colconArgs = @(
+        "--log-base", $ros2csLogBase,
+        "build",
+        "--base-paths", $ros2csSourcePath,
+        "--build-base", $ros2csBuildBase,
+        "--install-base", $ros2csInstallPath,
+        "--merge-install"
+    )
+    if ($verbose -or -not $quiet) {
+        $colconArgs += @("--event-handlers", "console_direct+")
+    }
+    $colconArgs += @(
+        "--cmake-args",
+        "-G", "Ninja",
+        "-DSTANDALONE_BUILD:int=$standalone_switch",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_TESTING:int=$tests_switch",
+        "-DPython3_EXECUTABLE:FILEPATH=$pythonExecutable",
+        "--no-warn-unused-cli"
+    )
+
+    Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -ForegroundColor Green
+    if ($quiet -and -not $verbose) {
+        Write-Host "Quiet mode: colcon console_direct+ is disabled; inspect logs under '$ros2csLogBase' on failure." -ForegroundColor Yellow
+    }
+
+    Invoke-Timed "ros2cs colcon build" {
+        & $colconExecutable @colconArgs
+        if($LASTEXITCODE -ne 0) {
+            throw "Ros2cs build failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    $assetRoot = Join-Path -Path $scriptPath -ChildPath "install\asset"
+    $assetSource = Join-Path -Path $scriptPath -ChildPath "src\Ros2ForUnity"
+    $assetDestination = Join-Path -Path $assetRoot -ChildPath "Ros2ForUnity"
+    Invoke-Timed "Unity asset staging" {
+        Invoke-RobocopyMirror -Source $assetSource -Destination $assetDestination
+    }
+    
+    $pluginPath = Join-Path -Path $assetDestination -ChildPath "Plugins"
+    Write-Host "Deploying build to $pluginPath" -ForegroundColor Green
+    Invoke-Timed "plugin deploy" {
+        & "$scriptPath\deploy_unity_plugins.ps1" $pluginPath $ros2csInstallPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "deploy_unity_plugins.ps1 failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    Invoke-Timed "metadata copy" {
+        Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\Windows\x86_64\ -Force
+        Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\ -Force
+    }
+}
+finally {
+    Write-TimingSummary
 }
 
 

--- a/build.ps1
+++ b/build.ps1
@@ -10,6 +10,13 @@
     Add ros2 binaries. Currently standalone flag is fixed to true, so there is no way to build without standalone libs. Parameter kept for future releases
 .PARAMETER clean_install
     Makes a clean installation. Removes install dir before deploying
+
+Modifications Copyright (c) 2026 Jianbin Liu.
+
+Modifications by Jianbin Liu:
+- Added strict/fail-fast behavior for Windows builds.
+- Routed ros2cs builds through the canonical ros2cs workspace with short build roots.
+- Preserved standalone asset deployment as the public Windows packaging path.
 #>
 Param (
     [Parameter(Mandatory=$false)][switch]$with_tests=$false,
@@ -68,10 +75,12 @@ if ($LASTEXITCODE -ne 0) {
     throw "metadata_generator.py failed with exit code $LASTEXITCODE"
 }
 
+# Resolve the junction target so colcon builds the canonical ros2cs workspace, not the R2FU src wrapper.
 $ros2csItem = Get-Item "$scriptPath\src\ros2cs" -Force
 $ros2csPath = if ($ros2csItem.Target -and $ros2csItem.Target.Count -gt 0) { $ros2csItem.Target[0] } else { $ros2csItem.FullName }
 $ros2csSourcePath = Join-Path -Path $ros2csPath -ChildPath "src"
 $ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
+# Keep generated ROS/MSVC object paths short while allowing CI or local scripts to override the roots.
 $ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { Get-DefaultWorkPath "r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
 $ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { Get-DefaultWorkPath "r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
 $pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) {

--- a/build.ps1
+++ b/build.ps1
@@ -12,7 +12,7 @@
     Makes a clean installation. Removes install dir before deploying
 .PARAMETER quiet
     Reduce live colcon console output. Full logs are still written under the configured colcon log base.
-.PARAMETER verbose
+.PARAMETER console_direct
     Preserve the chatty console_direct+ colcon output. This is the default for compatibility.
 
 Modifications Copyright (c) 2026 Jianbin Liu.
@@ -28,7 +28,7 @@ Param (
     [Parameter(Mandatory=$false)][switch]$standalone=$false,
     [Parameter(Mandatory=$false)][switch]$clean_install=$false,
     [Parameter(Mandatory=$false)][switch]$quiet=$false,
-    [Parameter(Mandatory=$false)][switch]$verbose=$false
+    [Parameter(Mandatory=$false)][switch]$console_direct=$false
 )
 
 $ErrorActionPreference = 'Stop'
@@ -95,7 +95,7 @@ function Invoke-RobocopyMirror {
         "/W:1",
         "/NP"
     )
-    if ($quiet -and -not $verbose) {
+    if ($quiet -and -not $console_direct) {
         $robocopyArgs += @("/NFL", "/NDL")
     }
 
@@ -179,7 +179,7 @@ try {
         "--install-base", $ros2csInstallPath,
         "--merge-install"
     )
-    if ($verbose -or -not $quiet) {
+    if ($console_direct -or -not $quiet) {
         $colconArgs += @("--event-handlers", "console_direct+")
     }
     $colconArgs += @(
@@ -193,7 +193,7 @@ try {
     )
 
     Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -ForegroundColor Green
-    if ($quiet -and -not $verbose) {
+    if ($quiet -and -not $console_direct) {
         Write-Host "Quiet mode: colcon console_direct+ is disabled; inspect logs under '$ros2csLogBase' on failure." -ForegroundColor Yellow
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
     Builds Ros2ForUnity asset
 .DESCRIPTION
-    This script builds Ros2DorUnity asset
+    This script builds Ros2ForUnity asset
 .PARAMETER with_tests
     Build tests
 .PARAMETER standalone
@@ -75,9 +75,9 @@ $ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
 $ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { Get-DefaultWorkPath "r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
 $ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { Get-DefaultWorkPath "r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
 $pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) {
-    Resolve-RequiredCommand "python" "Run this script through D:\ros2unity\tools\Enter-Ros2JazzyEnv.py, or set COLCON_PYTHON_EXECUTABLE."
+    Resolve-RequiredCommand "python" "Run this script from a sourced ROS 2 Jazzy environment, or set COLCON_PYTHON_EXECUTABLE."
 } else { $Env:COLCON_PYTHON_EXECUTABLE }
-$colconExecutable = Resolve-RequiredCommand "colcon" "Run this script through D:\ros2unity\tools\Enter-Ros2JazzyEnv.py so the Jazzy pixi colcon is on PATH."
+$colconExecutable = Resolve-RequiredCommand "colcon" "Run this script from a sourced ROS 2 Jazzy environment so colcon is on PATH."
 
 Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -ForegroundColor Green
 & $colconExecutable `
@@ -96,12 +96,12 @@ Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -Foregroun
     "-DPython3_EXECUTABLE:FILEPATH=$pythonExecutable" `
     --no-warn-unused-cli
 if($LASTEXITCODE -eq 0) {
-    md -Force $scriptPath\install\asset | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path -Path $scriptPath -ChildPath "install\asset") | Out-Null
     Copy-Item -Path $scriptPath\src\Ros2ForUnity -Destination $scriptPath\install\asset\ -Recurse -Force
     
-    $plugin_path=Join-Path -Path $scriptPath -ChildPath "\install\asset\Ros2ForUnity\Plugins\"
-    Write-Host "Deploying build to $plugin_path" -ForegroundColor Green
-    & "$scriptPath\deploy_unity_plugins.ps1" $plugin_path $ros2csInstallPath
+    $pluginPath = Join-Path -Path $scriptPath -ChildPath "install\asset\Ros2ForUnity\Plugins"
+    Write-Host "Deploying build to $pluginPath" -ForegroundColor Green
+    & "$scriptPath\deploy_unity_plugins.ps1" $pluginPath $ros2csInstallPath
     if ($LASTEXITCODE -ne 0) {
         throw "deploy_unity_plugins.ps1 failed with exit code $LASTEXITCODE"
     }

--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,29 @@ Set-StrictMode -Version Latest
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
+function Get-DefaultWorkPath {
+    param([Parameter(Mandatory=$true)][string]$Name)
+    $driveRoot = [System.IO.Path]::GetPathRoot($scriptPath)
+    if ([string]::IsNullOrEmpty($driveRoot))
+    {
+        $driveRoot = [System.IO.Path]::GetPathRoot((Get-Location).Path)
+    }
+    return Join-Path -Path $driveRoot -ChildPath $Name
+}
+
+function Resolve-RequiredCommand {
+    param(
+        [Parameter(Mandatory=$true)][string]$Name,
+        [Parameter(Mandatory=$true)][string]$Hint
+    )
+
+    try {
+        return (Get-Command $Name -ErrorAction Stop).Source
+    } catch {
+        throw "Required command '$Name' was not found. $Hint"
+    }
+}
+
 if(-Not (Test-Path -Path "$scriptPath\src\ros2cs")) {
     Write-Host "Pull repositories with 'pull_repositories.ps1' first." -ForegroundColor Red
     exit 1
@@ -49,10 +72,12 @@ $ros2csItem = Get-Item "$scriptPath\src\ros2cs" -Force
 $ros2csPath = if ($ros2csItem.Target -and $ros2csItem.Target.Count -gt 0) { $ros2csItem.Target[0] } else { $ros2csItem.FullName }
 $ros2csSourcePath = Join-Path -Path $ros2csPath -ChildPath "src"
 $ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
-$ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { "D:\r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
-$ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { "D:\r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
-$pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) { (Get-Command python).Source } else { $Env:COLCON_PYTHON_EXECUTABLE }
-$colconExecutable = (Get-Command colcon).Source
+$ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { Get-DefaultWorkPath "r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
+$ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { Get-DefaultWorkPath "r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
+$pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) {
+    Resolve-RequiredCommand "python" "Run this script through D:\ros2unity\tools\Enter-Ros2JazzyEnv.py, or set COLCON_PYTHON_EXECUTABLE."
+} else { $Env:COLCON_PYTHON_EXECUTABLE }
+$colconExecutable = Resolve-RequiredCommand "colcon" "Run this script through D:\ros2unity\tools\Enter-Ros2JazzyEnv.py so the Jazzy pixi colcon is on PATH."
 
 Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -ForegroundColor Green
 & $colconExecutable `

--- a/build.ps1
+++ b/build.ps1
@@ -11,6 +11,9 @@
 .PARAMETER clean_install
     Makes a clean installation. Removes install dir before deploying
 #>
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
 Param (
     [Parameter(Mandatory=$false)][switch]$with_tests=$false,
     [Parameter(Mandatory=$false)][switch]$standalone=$false,
@@ -24,7 +27,7 @@ if(-Not (Test-Path -Path "$scriptPath\src\ros2cs")) {
     exit 1
 }
 
-Write-Host $msg -ForegroundColor Green
+Write-Host "Building Ros2ForUnity asset..." -ForegroundColor Green
 $options = @{
     with_tests = $with_tests
     standalone = $standalone
@@ -36,19 +39,25 @@ if($clean_install) {
 }
 
 if($standalone) {
-  & "python" $SCRIPTPATH\src\scripts\metadata_generator.py --standalone
+  & "python" "$scriptPath\src\scripts\metadata_generator.py" --standalone
 } else {
-  & "python" $SCRIPTPATH\src\scripts\metadata_generator.py
+  & "python" "$scriptPath\src\scripts\metadata_generator.py"
+}
+if ($LASTEXITCODE -ne 0) {
+    throw "metadata_generator.py failed with exit code $LASTEXITCODE"
 }
 
 & "$scriptPath\src\ros2cs\build.ps1" @options
-if($?) {
+if($LASTEXITCODE -eq 0) {
     md -Force $scriptPath\install\asset | Out-Null
     Copy-Item -Path $scriptPath\src\Ros2ForUnity -Destination $scriptPath\install\asset\ -Recurse -Force
     
     $plugin_path=Join-Path -Path $scriptPath -ChildPath "\install\asset\Ros2ForUnity\Plugins\"
     Write-Host "Deploying build to $plugin_path" -ForegroundColor Green
     & "$scriptPath\deploy_unity_plugins.ps1" $plugin_path
+    if ($LASTEXITCODE -ne 0) {
+        throw "deploy_unity_plugins.ps1 failed with exit code $LASTEXITCODE"
+    }
 
     Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\Windows\x86_64\
     Copy-Item -Path $scriptPath\src\Ros2ForUnity\metadata_ros2cs.xml -Destination $scriptPath\install\asset\Ros2ForUnity\Plugins\

--- a/build.ps1
+++ b/build.ps1
@@ -162,14 +162,16 @@ try {
     $ros2csItem = Get-Item "$scriptPath\src\ros2cs" -Force
     $ros2csPath = if ($ros2csItem.Target -and $ros2csItem.Target.Count -gt 0) { $ros2csItem.Target[0] } else { $ros2csItem.FullName }
     $ros2csSourcePath = Join-Path -Path $ros2csPath -ChildPath "src"
-    $ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
+    $ros2csInstallPath = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_INSTALL_BASE)) {
+        Join-Path -Path $ros2csPath -ChildPath "install"
+    } else { $Env:R2FU_ROS2CS_INSTALL_BASE }
     # Keep generated ROS/MSVC object paths short while allowing CI or local scripts to override the roots.
     $ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { Get-DefaultWorkPath "r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
     $ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { Get-DefaultWorkPath "r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
     $pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) {
-        Resolve-RequiredCommand "python" "Run this script from a sourced ROS 2 Jazzy environment, or set COLCON_PYTHON_EXECUTABLE."
+        Resolve-RequiredCommand "python" "Run this script from a sourced ROS 2 environment, or set COLCON_PYTHON_EXECUTABLE."
     } else { $Env:COLCON_PYTHON_EXECUTABLE }
-    $colconExecutable = Resolve-RequiredCommand "colcon" "Run this script from a sourced ROS 2 Jazzy environment so colcon is on PATH."
+    $colconExecutable = Resolve-RequiredCommand "colcon" "Run this script from a sourced ROS 2 environment so colcon is on PATH."
 
     $colconArgs = @(
         "--log-base", $ros2csLogBase,

--- a/build.ps1
+++ b/build.ps1
@@ -11,14 +11,14 @@
 .PARAMETER clean_install
     Makes a clean installation. Removes install dir before deploying
 #>
-$ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
-
 Param (
     [Parameter(Mandatory=$false)][switch]$with_tests=$false,
     [Parameter(Mandatory=$false)][switch]$standalone=$false,
     [Parameter(Mandatory=$false)][switch]$clean_install=$false
 )
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
@@ -28,10 +28,8 @@ if(-Not (Test-Path -Path "$scriptPath\src\ros2cs")) {
 }
 
 Write-Host "Building Ros2ForUnity asset..." -ForegroundColor Green
-$options = @{
-    with_tests = $with_tests
-    standalone = $standalone
-}
+$tests_switch = if ($with_tests) { 1 } else { 0 }
+$standalone_switch = if ($standalone) { 1 } else { 0 }
 
 if($clean_install) {
     Write-Host "Cleaning install directory..." -ForegroundColor White
@@ -47,14 +45,38 @@ if ($LASTEXITCODE -ne 0) {
     throw "metadata_generator.py failed with exit code $LASTEXITCODE"
 }
 
-& "$scriptPath\src\ros2cs\build.ps1" @options
+$ros2csItem = Get-Item "$scriptPath\src\ros2cs" -Force
+$ros2csPath = if ($ros2csItem.Target -and $ros2csItem.Target.Count -gt 0) { $ros2csItem.Target[0] } else { $ros2csItem.FullName }
+$ros2csSourcePath = Join-Path -Path $ros2csPath -ChildPath "src"
+$ros2csInstallPath = Join-Path -Path $ros2csPath -ChildPath "install"
+$ros2csBuildBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_BUILD_BASE)) { "D:\r2fu_b" } else { $Env:R2FU_ROS2CS_BUILD_BASE }
+$ros2csLogBase = if ([string]::IsNullOrEmpty($Env:R2FU_ROS2CS_LOG_BASE)) { "D:\r2fu_l" } else { $Env:R2FU_ROS2CS_LOG_BASE }
+$pythonExecutable = if ([string]::IsNullOrEmpty($Env:COLCON_PYTHON_EXECUTABLE)) { (Get-Command python).Source } else { $Env:COLCON_PYTHON_EXECUTABLE }
+$colconExecutable = (Get-Command colcon).Source
+
+Write-Host "Building ros2cs from '$ros2csPath' with Ninja/Release..." -ForegroundColor Green
+& $colconExecutable `
+    --log-base $ros2csLogBase `
+    build `
+    --base-paths $ros2csSourcePath `
+    --build-base $ros2csBuildBase `
+    --install-base $ros2csInstallPath `
+    --merge-install `
+    --event-handlers console_direct+ `
+    --cmake-args `
+    -G Ninja `
+    -DSTANDALONE_BUILD:int=$standalone_switch `
+    -DCMAKE_BUILD_TYPE=Release `
+    -DBUILD_TESTING:int=$tests_switch `
+    "-DPython3_EXECUTABLE:FILEPATH=$pythonExecutable" `
+    --no-warn-unused-cli
 if($LASTEXITCODE -eq 0) {
     md -Force $scriptPath\install\asset | Out-Null
     Copy-Item -Path $scriptPath\src\Ros2ForUnity -Destination $scriptPath\install\asset\ -Recurse -Force
     
     $plugin_path=Join-Path -Path $scriptPath -ChildPath "\install\asset\Ros2ForUnity\Plugins\"
     Write-Host "Deploying build to $plugin_path" -ForegroundColor Green
-    & "$scriptPath\deploy_unity_plugins.ps1" $plugin_path
+    & "$scriptPath\deploy_unity_plugins.ps1" $plugin_path $ros2csInstallPath
     if ($LASTEXITCODE -ne 0) {
         throw "deploy_unity_plugins.ps1 failed with exit code $LASTEXITCODE"
     }

--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,7 @@ fi
 # Delegate to ros2cs' own build entrypoint so R2FU does not duplicate colcon/toolchain policy.
 if run_timed "ros2cs build" "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
     run_timed "Unity asset staging" bash -c 'mkdir -p "$2" && rm -rf "$3" && cp -a "$1" "$2/"' _ "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset" "$SCRIPTPATH/install/asset/Ros2ForUnity"
-    run_timed "plugin deploy" "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
+    run_timed "plugin deploy" "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/" "$SCRIPTPATH/src/ros2cs/install"
     metadata_start_ns=$(date +%s%N)
     for metadata_target in \
       "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml" \

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ if [ ! -d "$SCRIPTPATH/src/ros2cs" ]; then
     exit 1
 fi
 
-OPTIONS=""
+OPTIONS=()
 STANDALONE=0
 TESTS=0
 CLEAN_INSTALL=0
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
     -t|--with-tests)
-      OPTIONS="$OPTIONS --with-tests"
+      OPTIONS+=("--with-tests")
       TESTS=1
       shift # past argument
       ;;
@@ -38,7 +38,7 @@ while [[ $# -gt 0 ]]; do
         echo "Patchelf missing. Standalone build requires patchelf. Install it via apt 'sudo apt install patchelf'."
         exit 1
       fi
-      OPTIONS="$OPTIONS --standalone"
+      OPTIONS+=("--standalone")
       STANDALONE=1
       shift # past argument
       ;;
@@ -51,8 +51,10 @@ while [[ $# -gt 0 ]]; do
       exit 0
       shift # past argument
       ;;
-    *)    # unknown option
-      shift # past argument
+    *)
+      echo "Unknown option: $1"
+      display_usage
+      exit 1
       ;;
   esac
 done
@@ -70,7 +72,7 @@ else
   python3 "$SCRIPTPATH/src/scripts/metadata_generator.py"
 fi
 
-if "$SCRIPTPATH/src/ros2cs/build.sh" $OPTIONS; then
+if "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
     mkdir -p "$SCRIPTPATH/install/asset" && cp -R "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset/"
     "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
     cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml"

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ while [[ $# -gt 0 ]]; do
       shift # past argument
       ;;
     -s|--standalone)
-      if ! hash patchelf 2>/dev/null ; then
+      if ! command -v patchelf >/dev/null 2>&1 ; then
         echo "Patchelf missing. Standalone build requires patchelf. Install it via apt 'sudo apt install patchelf'."
         exit 1
       fi
@@ -109,7 +109,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ "$CLEAN_INSTALL" == 1 ]; then
-    run_timed "clean install" bash -c "echo 'Cleaning install directory...' && rm -rf \"\$0\" && mkdir -p \"\$0\"" "$SCRIPTPATH/install"
+    run_timed "clean install" bash -c 'echo "Cleaning install directory..." && rm -rf "$1" && mkdir -p "$1"' _ "$SCRIPTPATH/install"
 fi
 
 if [ "$STANDALONE" == 1 ]; then
@@ -120,7 +120,7 @@ fi
 
 # Delegate to ros2cs' own build entrypoint so R2FU does not duplicate colcon/toolchain policy.
 if run_timed "ros2cs build" "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
-    run_timed "Unity asset staging" bash -c "mkdir -p \"\$1\" && rm -rf \"\$2\" && cp -a \"\$0\" \"\$1/\"" "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset" "$SCRIPTPATH/install/asset/Ros2ForUnity"
+    run_timed "Unity asset staging" bash -c 'mkdir -p "$2" && rm -rf "$3" && cp -a "$1" "$2/"' _ "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset" "$SCRIPTPATH/install/asset/Ros2ForUnity"
     run_timed "plugin deploy" "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
     metadata_start_ns=$(date +%s%N)
     for metadata_target in \

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,6 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       display_usage
       exit 0
-      shift # past argument
       ;;
     *)
       echo "Unknown option: $1"
@@ -61,9 +60,8 @@ done
 
 if [ "$CLEAN_INSTALL" == 1 ]; then
     echo "Cleaning install directory..."
-    if [ -d "$SCRIPTPATH/install" ]; then
-      rm -rf "$SCRIPTPATH/install"/*
-    fi
+    rm -rf "$SCRIPTPATH/install"
+    mkdir -p "$SCRIPTPATH/install"
 fi
 
 if [ "$STANDALONE" == 1 ]; then
@@ -75,8 +73,11 @@ fi
 if "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
     mkdir -p "$SCRIPTPATH/install/asset" && cp -R "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset/"
     "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
-    cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml"
-    cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/metadata_ros2cs.xml"
+    for metadata_target in \
+      "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml" \
+      "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/metadata_ros2cs.xml"; do
+      cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$metadata_target"
+    done
 else
     echo "Ros2cs build failed!"
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added strict/fail-fast behavior for Linux builds.
+# - Kept Ros2ForUnity asset deployment explicit after ros2cs build completion.
+
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
@@ -70,6 +76,7 @@ else
   python3 "$SCRIPTPATH/src/scripts/metadata_generator.py"
 fi
 
+# Delegate to ros2cs' own build entrypoint so R2FU does not duplicate colcon/toolchain policy.
 if "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
     mkdir -p "$SCRIPTPATH/install/asset" && cp -R "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset/"
     "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-SCRIPT=$(readlink -f $0)
-SCRIPTPATH=`dirname $SCRIPT`
+set -euo pipefail
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
 
 display_usage() {
     echo "Usage: "
@@ -55,22 +57,24 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [ $CLEAN_INSTALL == 1 ]; then
+if [ "$CLEAN_INSTALL" == 1 ]; then
     echo "Cleaning install directory..."
-    rm -rf $SCRIPTPATH/install/*
+    if [ -d "$SCRIPTPATH/install" ]; then
+      rm -rf "$SCRIPTPATH/install"/*
+    fi
 fi
 
-if [ $STANDALONE == 1 ]; then
-  python3 $SCRIPTPATH/src/scripts/metadata_generator.py --standalone
+if [ "$STANDALONE" == 1 ]; then
+  python3 "$SCRIPTPATH/src/scripts/metadata_generator.py" --standalone
 else
-  python3 $SCRIPTPATH/src/scripts/metadata_generator.py
+  python3 "$SCRIPTPATH/src/scripts/metadata_generator.py"
 fi
 
-if $SCRIPTPATH/src/ros2cs/build.sh $OPTIONS; then
-    mkdir -p $SCRIPTPATH/install/asset && cp -R $SCRIPTPATH/src/Ros2ForUnity $SCRIPTPATH/install/asset/
-    $SCRIPTPATH/deploy_unity_plugins.sh $SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/
-    cp $SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml $SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml
-    cp $SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml $SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/metadata_ros2cs.xml
+if "$SCRIPTPATH/src/ros2cs/build.sh" $OPTIONS; then
+    mkdir -p "$SCRIPTPATH/install/asset" && cp -R "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset/"
+    "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
+    cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml"
+    cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/metadata_ros2cs.xml"
 else
     echo "Ros2cs build failed!"
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,55 @@
 # Modifications by Jianbin Liu:
 # - Added strict/fail-fast behavior for Linux builds.
 # - Kept Ros2ForUnity asset deployment explicit after ros2cs build completion.
+# - Added phase timing for R2FU wrapper build and deployment steps.
 
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
+TIMING_NAMES=()
+TIMING_MS=()
+TOTAL_START_NS=$(date +%s%N)
+
+elapsed_ms() {
+  local start_ns="$1"
+  local end_ns
+  end_ns=$(date +%s%N)
+  echo $(((end_ns - start_ns) / 1000000))
+}
+
+record_timing() {
+  TIMING_NAMES+=("$1")
+  TIMING_MS+=("$2")
+}
+
+print_timing_summary() {
+  local total_ms
+  total_ms=$(elapsed_ms "$TOTAL_START_NS")
+  echo ""
+  echo "Ros2ForUnity build timing summary:"
+  local i
+  for ((i = 0; i < ${#TIMING_NAMES[@]}; i++)); do
+    printf '  %-28s %8.3fs\n' "${TIMING_NAMES[$i]}" "$(awk "BEGIN { print ${TIMING_MS[$i]} / 1000 }")"
+  done
+  printf '  %-28s %8.3fs\n' "total" "$(awk "BEGIN { print $total_ms / 1000 }")"
+}
+
+run_timed() {
+  local name="$1"
+  shift
+  local start_ns
+  local status
+  start_ns=$(date +%s%N)
+  set +e
+  "$@"
+  status=$?
+  set -e
+  record_timing "$name" "$(elapsed_ms "$start_ns")"
+  return "$status"
+}
+
+trap print_timing_summary EXIT
 
 display_usage() {
     echo "Usage: "
@@ -65,26 +109,26 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ "$CLEAN_INSTALL" == 1 ]; then
-    echo "Cleaning install directory..."
-    rm -rf "$SCRIPTPATH/install"
-    mkdir -p "$SCRIPTPATH/install"
+    run_timed "clean install" bash -c "echo 'Cleaning install directory...' && rm -rf \"\$0\" && mkdir -p \"\$0\"" "$SCRIPTPATH/install"
 fi
 
 if [ "$STANDALONE" == 1 ]; then
-  python3 "$SCRIPTPATH/src/scripts/metadata_generator.py" --standalone
+  run_timed "metadata generation" python3 "$SCRIPTPATH/src/scripts/metadata_generator.py" --standalone
 else
-  python3 "$SCRIPTPATH/src/scripts/metadata_generator.py"
+  run_timed "metadata generation" python3 "$SCRIPTPATH/src/scripts/metadata_generator.py"
 fi
 
 # Delegate to ros2cs' own build entrypoint so R2FU does not duplicate colcon/toolchain policy.
-if "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
-    mkdir -p "$SCRIPTPATH/install/asset" && cp -R "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset/"
-    "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
+if run_timed "ros2cs build" "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
+    run_timed "Unity asset staging" bash -c "mkdir -p \"\$1\" && rm -rf \"\$2\" && cp -a \"\$0\" \"\$1/\"" "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset" "$SCRIPTPATH/install/asset/Ros2ForUnity"
+    run_timed "plugin deploy" "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/"
+    metadata_start_ns=$(date +%s%N)
     for metadata_target in \
       "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/Linux/x86_64/metadata_ros2cs.xml" \
       "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/metadata_ros2cs.xml"; do
       cp "$SCRIPTPATH/src/Ros2ForUnity/metadata_ros2cs.xml" "$metadata_target"
     done
+    record_timing "metadata copy" "$(elapsed_ms "$metadata_start_ns")"
 else
     echo "Ros2cs build failed!"
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -120,7 +120,11 @@ fi
 
 # Delegate to ros2cs' own build entrypoint so R2FU does not duplicate colcon/toolchain policy.
 if run_timed "ros2cs build" "$SCRIPTPATH/src/ros2cs/build.sh" "${OPTIONS[@]}"; then
-    run_timed "Unity asset staging" bash -c 'mkdir -p "$2" && rm -rf "$3" && cp -a "$1" "$2/"' _ "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset" "$SCRIPTPATH/install/asset/Ros2ForUnity"
+    if command -v rsync >/dev/null 2>&1; then
+      run_timed "Unity asset staging" bash -c 'mkdir -p "$2" && rsync --archive --delete "$1/" "$2/"' _ "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset/Ros2ForUnity"
+    else
+      run_timed "Unity asset staging" bash -c 'mkdir -p "$2" && rm -rf "$3" && cp -a "$1" "$2/"' _ "$SCRIPTPATH/src/Ros2ForUnity" "$SCRIPTPATH/install/asset" "$SCRIPTPATH/install/asset/Ros2ForUnity"
+    fi
     run_timed "plugin deploy" "$SCRIPTPATH/deploy_unity_plugins.sh" "$SCRIPTPATH/install/asset/Ros2ForUnity/Plugins/" "$SCRIPTPATH/src/ros2cs/install"
     metadata_start_ns=$(date +%s%N)
     for metadata_target in \

--- a/create_unity_package.ps1
+++ b/create_unity_package.ps1
@@ -12,6 +12,12 @@
     Unity package name
 .PARAMETER output_dir
     output file directory
+
+Modifications Copyright (c) 2026 Jianbin Liu.
+
+Modifications by Jianbin Liu:
+- Added strict/fail-fast Unity package creation.
+- Sanitized Unity-version-derived temporary paths before filesystem use.
 #>
 Param (
     [Parameter(Mandatory=$true)][string]$unity_path,

--- a/create_unity_package.ps1
+++ b/create_unity_package.ps1
@@ -13,6 +13,9 @@
 .PARAMETER output_dir
     output file directory
 #>
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
 Param (
     [Parameter(Mandatory=$true)][string]$unity_path,
     [Parameter(Mandatory=$false)][string]$input_asset,
@@ -40,7 +43,15 @@ if(-Not (Test-Path -Path "$output_dir")) {
     mkdir ${output_dir} | Out-Null
 }
 
-& "$unity_path" -version | Tee-Object -Variable unity_version | Out-Null
+if (-Not (Test-Path -Path "$unity_path")) {
+    throw "Unity editor executable '$unity_path' does not exist."
+}
+
+$unityVersionOutput = & "$unity_path" -version
+if ($LASTEXITCODE -ne 0) {
+    throw "Unity editor version check failed with exit code $LASTEXITCODE"
+}
+$unity_version = ($unityVersionOutput | Select-Object -First 1).Trim()
 
 if ($unity_version -match '^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$') {
     Write-Host "Unity editor confirmed."
@@ -58,7 +69,8 @@ if ($unity_version -match '^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$') {
 }
 Write-Host "Using ${unity_path} editor."
 
-$tmp_project_path = Join-Path -Path "$temp_dir" -ChildPath "\ros2cs_unity_project\$unity_version"
+$safe_unity_version = $unity_version -replace '[^A-Za-z0-9._-]', '_'
+$tmp_project_path = Join-Path -Path "$temp_dir" -ChildPath "\ros2cs_unity_project\$safe_unity_version"
 
 # Create temp project
 if(Test-Path -Path "$tmp_project_path") {
@@ -67,6 +79,9 @@ if(Test-Path -Path "$tmp_project_path") {
 } else {
     Write-Host "Creating Unity temporary project for Unity $unity_version..."
     & "$unity_path" -createProject "$tmp_project_path" -batchmode -quit | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unity project creation failed with exit code $LASTEXITCODE"
+    }
 }
 
 # Copy asset
@@ -76,6 +91,9 @@ Copy-Item -Path "$input_asset" -Destination "$tmp_project_path\Assets\$package_n
 # Creating asset
 Write-Host "Saving unitypackage '$output_dir\$package_name.unitypackage'..."
 & "$unity_path" -projectPath "$tmp_project_path" -exportPackage "Assets\$package_name" "$output_dir\$package_name.unitypackage" -batchmode -quit | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Unity package export failed with exit code $LASTEXITCODE"
+}
 
 # Cleaning up
 Write-Host "Cleaning up temporary project..."

--- a/create_unity_package.ps1
+++ b/create_unity_package.ps1
@@ -13,15 +13,15 @@
 .PARAMETER output_dir
     output file directory
 #>
-$ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
-
 Param (
     [Parameter(Mandatory=$true)][string]$unity_path,
     [Parameter(Mandatory=$false)][string]$input_asset,
     [Parameter(Mandatory=$false)][string]$package_name="Ros2ForUnity",
     [Parameter(Mandatory=$false)][string]$output_dir
 )
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $temp_dir = $Env:TEMP

--- a/create_unity_package.ps1
+++ b/create_unity_package.ps1
@@ -53,11 +53,36 @@ if (-Not (Test-Path -LiteralPath "$unity_path")) {
     throw "Unity editor executable '$unity_path' does not exist."
 }
 
-$unityVersionOutput = & "$unity_path" -version
-if ($LASTEXITCODE -ne 0) {
-    throw "Unity editor version check failed with exit code $LASTEXITCODE"
+function Get-UnityVersionFromPath {
+    param([Parameter(Mandatory=$true)][string]$UnityPath)
+    $normalizedPath = $UnityPath -replace '/', '\'
+    if ($normalizedPath -match '\\(?<version>[0-9]{4}\.[0-9]+\.[0-9]+f?[0-9]*)\\Editor\\Unity(?:\.exe)?$') {
+        return $Matches['version']
+    }
+    return $null
 }
-$unity_version = ($unityVersionOutput | Select-Object -First 1).Trim()
+
+$unity_version = Get-UnityVersionFromPath -UnityPath $unity_path
+if ([string]::IsNullOrEmpty($unity_version)) {
+    $unityVersionOutput = & "$unity_path" -version
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unity editor version check failed with exit code $LASTEXITCODE"
+    }
+    $unity_version = ($unityVersionOutput | Select-Object -First 1).Trim()
+}
+
+function Mirror-Directory {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Destination
+    )
+    & robocopy $Source $Destination /MIR /R:1 /W:0 /NP /NFL /NDL /NJH /NJS
+    $robocopyExitCode = $LASTEXITCODE
+    if ($robocopyExitCode -gt 7) {
+        throw "robocopy failed from '$Source' to '$Destination' with exit code $robocopyExitCode"
+    }
+    $global:LASTEXITCODE = 0
+}
 
 if ($unity_version -match '^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$') {
     Write-Host "Unity editor confirmed."
@@ -101,7 +126,7 @@ if(Test-Path -LiteralPath "$tmp_project_path") {
 
 # Copy asset
 Write-Host "Copying asset '$input_asset' to export..."
-Copy-Item -LiteralPath "$input_asset" -Destination (Join-Path -Path $assetsPath -ChildPath $package_name) -Recurse
+Mirror-Directory -Source "$input_asset" -Destination (Join-Path -Path $assetsPath -ChildPath $package_name)
 
 # Creating asset
 Write-Host "Saving unitypackage '$output_dir\$package_name.unitypackage'..."

--- a/create_unity_package.ps1
+++ b/create_unity_package.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
     Creates a 'unitypackage' from an input asset.
 .DESCRIPTION
-    This script screates a temporary Unity project in "%USERPROFILE%\AppData\Local\Temp" directory, copy input asset and makes an unity package out of it. Valid Unity license is required.
+    This script creates a temporary Unity project in "%USERPROFILE%\AppData\Local\Temp" directory, copies the input asset, and makes a unity package out of it. Valid Unity license is required.
 .PARAMETER unity_path
     Unity editor executable path
 .PARAMETER input_asset
@@ -27,11 +27,11 @@ $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $temp_dir = $Env:TEMP
 
 if(-Not $PSBoundParameters.ContainsKey('input_asset')) {
-    $input_asset= Join-Path -Path $scriptPath -ChildPath "\install\asset\Ros2ForUnity"
+    $input_asset= Join-Path -Path $scriptPath -ChildPath "install\asset\Ros2ForUnity"
 }
 
 if(-Not $PSBoundParameters.ContainsKey('output_dir')) {
-    $output_dir= Join-Path -Path $scriptPath -ChildPath "\install\unity_package"
+    $output_dir= Join-Path -Path $scriptPath -ChildPath "install\unity_package"
 }
 
 if(-Not (Test-Path -Path "$input_asset")) {
@@ -40,7 +40,7 @@ if(-Not (Test-Path -Path "$input_asset")) {
 }
 
 if(-Not (Test-Path -Path "$output_dir")) {
-    mkdir ${output_dir} | Out-Null
+    New-Item -ItemType Directory -Force -Path $output_dir | Out-Null
 }
 
 if (-Not (Test-Path -Path "$unity_path")) {
@@ -56,7 +56,7 @@ $unity_version = ($unityVersionOutput | Select-Object -First 1).Trim()
 if ($unity_version -match '^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$') {
     Write-Host "Unity editor confirmed."
 } else {
-    while (1) {
+    while ($true) {
         $confirmation = Read-Host "Can't confirm Unity editor. Do you want to force $unity_path as an Unity editor executable? [y]es or [n]o"
         if ($confirmation -eq 'y' -or $confirmation -eq 'Y') {
             break;
@@ -70,12 +70,13 @@ if ($unity_version -match '^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$') {
 Write-Host "Using ${unity_path} editor."
 
 $safe_unity_version = $unity_version -replace '[^A-Za-z0-9._-]', '_'
-$tmp_project_path = Join-Path -Path "$temp_dir" -ChildPath "\ros2cs_unity_project\$safe_unity_version"
+$tmp_project_path = Join-Path -Path "$temp_dir" -ChildPath "ros2cs_unity_project\$safe_unity_version"
 
 # Create temp project
 if(Test-Path -Path "$tmp_project_path") {
     Write-Host "Found existing temporary project for Unity $unity_version."
-    Remove-Item -Path "$tmp_project_path\Assets\*" -Force -Recurse -ErrorAction Ignore
+    Remove-Item -Path "$tmp_project_path\Assets" -Force -Recurse -ErrorAction Ignore
+    New-Item -ItemType Directory -Force -Path "$tmp_project_path\Assets" | Out-Null
 } else {
     Write-Host "Creating Unity temporary project for Unity $unity_version..."
     & "$unity_path" -createProject "$tmp_project_path" -batchmode -quit | Out-Null

--- a/create_unity_package.ps1
+++ b/create_unity_package.ps1
@@ -29,7 +29,7 @@ Param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $temp_dir = $Env:TEMP
 
 if(-Not $PSBoundParameters.ContainsKey('input_asset')) {
@@ -40,16 +40,16 @@ if(-Not $PSBoundParameters.ContainsKey('output_dir')) {
     $output_dir= Join-Path -Path $scriptPath -ChildPath "install\unity_package"
 }
 
-if(-Not (Test-Path -Path "$input_asset")) {
+if(-Not (Test-Path -LiteralPath "$input_asset")) {
     Write-Host "Input asset '$input_asset' doesn't exist! Use 'build.ps1' to build project first." -ForegroundColor Red
     exit 1
 }
 
-if(-Not (Test-Path -Path "$output_dir")) {
+if(-Not (Test-Path -LiteralPath "$output_dir")) {
     New-Item -ItemType Directory -Force -Path $output_dir | Out-Null
 }
 
-if (-Not (Test-Path -Path "$unity_path")) {
+if (-Not (Test-Path -LiteralPath "$unity_path")) {
     throw "Unity editor executable '$unity_path' does not exist."
 }
 
@@ -76,35 +76,44 @@ if ($unity_version -match '^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$') {
 Write-Host "Using ${unity_path} editor."
 
 $safe_unity_version = $unity_version -replace '[^A-Za-z0-9._-]', '_'
+if ([string]::IsNullOrEmpty($safe_unity_version)) {
+    throw "Cannot derive a safe Unity version path from '$unity_version'."
+}
 $tmp_project_path = Join-Path -Path "$temp_dir" -ChildPath "ros2cs_unity_project\$safe_unity_version"
+$unityLogDir = Join-Path -Path "$temp_dir" -ChildPath "ros2cs_unity_project_logs"
+New-Item -ItemType Directory -Force -Path $unityLogDir | Out-Null
+$createProjectLog = Join-Path -Path $unityLogDir -ChildPath "create_$safe_unity_version.log"
+$exportPackageLog = Join-Path -Path $unityLogDir -ChildPath "export_$safe_unity_version.log"
+$assetsPath = Join-Path -Path $tmp_project_path -ChildPath "Assets"
 
 # Create temp project
-if(Test-Path -Path "$tmp_project_path") {
+if(Test-Path -LiteralPath "$tmp_project_path") {
     Write-Host "Found existing temporary project for Unity $unity_version."
-    Remove-Item -Path "$tmp_project_path\Assets" -Force -Recurse -ErrorAction Ignore
-    New-Item -ItemType Directory -Force -Path "$tmp_project_path\Assets" | Out-Null
+    Remove-Item -LiteralPath $assetsPath -Force -Recurse -ErrorAction Ignore
+    New-Item -ItemType Directory -Force -Path $assetsPath | Out-Null
 } else {
     Write-Host "Creating Unity temporary project for Unity $unity_version..."
-    & "$unity_path" -createProject "$tmp_project_path" -batchmode -quit | Out-Null
+    & "$unity_path" -createProject "$tmp_project_path" -batchmode -quit 2>&1 | Tee-Object -FilePath $createProjectLog | Out-Null
     if ($LASTEXITCODE -ne 0) {
-        throw "Unity project creation failed with exit code $LASTEXITCODE"
+        throw "Unity project creation failed with exit code $LASTEXITCODE. See log: $createProjectLog"
     }
 }
 
 # Copy asset
 Write-Host "Copying asset '$input_asset' to export..."
-Copy-Item -Path "$input_asset" -Destination "$tmp_project_path\Assets\$package_name" -Recurse
+Copy-Item -LiteralPath "$input_asset" -Destination (Join-Path -Path $assetsPath -ChildPath $package_name) -Recurse
 
 # Creating asset
 Write-Host "Saving unitypackage '$output_dir\$package_name.unitypackage'..."
-& "$unity_path" -projectPath "$tmp_project_path" -exportPackage "Assets\$package_name" "$output_dir\$package_name.unitypackage" -batchmode -quit | Out-Null
+& "$unity_path" -projectPath "$tmp_project_path" -exportPackage "Assets\$package_name" "$output_dir\$package_name.unitypackage" -batchmode -quit 2>&1 | Tee-Object -FilePath $exportPackageLog | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    throw "Unity package export failed with exit code $LASTEXITCODE"
+    throw "Unity package export failed with exit code $LASTEXITCODE. See log: $exportPackageLog"
 }
 
 # Cleaning up
 Write-Host "Cleaning up temporary project..."
-Remove-Item -Path "$tmp_project_path\Assets\*" -Force -Recurse -ErrorAction Ignore
+Remove-Item -LiteralPath $assetsPath -Force -Recurse -ErrorAction Ignore
+New-Item -ItemType Directory -Force -Path $assetsPath | Out-Null
 
 Write-Host "Done!" -ForegroundColor Green
 

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -17,13 +17,13 @@ display_usage() {
   echo "create_unity_package.sh -u <UNITY_PATH> -i [INPUT_ASSET] -p [PACKAGE_NAME] -o [OUTPUT_DIR]"
   echo ""
   echo "UNITY_PATH - Unity editor executable path"
-  echo "INPUT_ASSET - input asset to pack into unity package, default = 'install/asset/Ros2ForUnity'"
+  echo "INPUT_ASSET - input asset to pack into unity package, default = '<script dir>/install/asset/Ros2ForUnity'"
   echo "PACKAGE_NAME - unity package name, default = 'Ros2ForUnity'"
   echo "OUTPUT_DIR - output file directory, default = 'install/unity_package'"
 }
 
 UNITY_PATH=""
-INPUT_ASSET="install/asset/Ros2ForUnity"
+INPUT_ASSET="$SCRIPTPATH/install/asset/Ros2ForUnity"
 PACKAGE_NAME="Ros2ForUnity"
 OUTPUT_DIR="$SCRIPTPATH/install/unity_package"
 
@@ -101,6 +101,10 @@ echo "Using \"${UNITY_PATH}\" editor."
 
 TMP_ROOT="${TMPDIR:-/tmp}"
 TMP_PROJECT_PATH="$TMP_ROOT/ros2cs_unity_project/$SAFE_UNITY_VERSION"
+UNITY_LOG_DIR="$TMP_ROOT/ros2cs_unity_project_logs"
+CREATE_PROJECT_LOG="$UNITY_LOG_DIR/create_$SAFE_UNITY_VERSION.log"
+EXPORT_PACKAGE_LOG="$UNITY_LOG_DIR/export_$SAFE_UNITY_VERSION.log"
+mkdir -p "$UNITY_LOG_DIR"
 # Create temp project
 if [ -d "$TMP_PROJECT_PATH" ]; then
     echo "Found existing temporary project for Unity $UNITY_VERSION."
@@ -108,7 +112,10 @@ if [ -d "$TMP_PROJECT_PATH" ]; then
     mkdir -p "$TMP_PROJECT_PATH/Assets"
 else
   echo "Creating Unity temporary project for Unity $UNITY_VERSION..."
-  "$UNITY_PATH" -createProject "$TMP_PROJECT_PATH" -batchmode -quit
+  if ! "$UNITY_PATH" -createProject "$TMP_PROJECT_PATH" -batchmode -quit 2>&1 | tee "$CREATE_PROJECT_LOG"; then
+    echo "Unity project creation failed. See log: $CREATE_PROJECT_LOG" >&2
+    exit 1
+  fi
 fi
 
 # Copy asset
@@ -118,7 +125,10 @@ cp -r "$INPUT_ASSET" "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME"
 # Creating asset
 echo "Saving unitypackage '$OUTPUT_DIR/$PACKAGE_NAME.unitypackage'..."
 mkdir -p "$OUTPUT_DIR"
-"$UNITY_PATH" -projectPath "$TMP_PROJECT_PATH" -exportPackage "Assets/$PACKAGE_NAME" "$OUTPUT_DIR/$PACKAGE_NAME.unitypackage" -batchmode -quit
+if ! "$UNITY_PATH" -projectPath "$TMP_PROJECT_PATH" -exportPackage "Assets/$PACKAGE_NAME" "$OUTPUT_DIR/$PACKAGE_NAME.unitypackage" -batchmode -quit 2>&1 | tee "$EXPORT_PACKAGE_LOG"; then
+  echo "Unity package export failed. See log: $EXPORT_PACKAGE_LOG" >&2
+  exit 1
+fi
 
 # Cleaning up
 echo "Cleaning up temporary project..."

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added strict/fail-fast Unity package creation.
+# - Sanitized Unity-version-derived temporary paths before filesystem use.
+
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
-SCRIPT=$(readlink -f $0)
-SCRIPTPATH=`dirname $SCRIPT`
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
 
 display_usage() {
   echo "This script creates a temporary Unity project in '/tmp' directory, copy input asset and makes an unity package out of it. Valid Unity license is required."
@@ -67,7 +68,8 @@ if [ ! -d "$INPUT_ASSET" ]; then
     exit 1
 fi
 
-UNITY_VERSION=`$UNITY_PATH -version`
+UNITY_VERSION=$("$UNITY_PATH" -version | head -n 1)
+SAFE_UNITY_VERSION=$(echo "$UNITY_VERSION" | tr -c 'A-Za-z0-9._-' '_')
 
 # Test if unity editor is valid
 if [[ $UNITY_VERSION =~ ^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$ ]]; then
@@ -86,15 +88,15 @@ fi
 
 echo "Using \"${UNITY_PATH}\" editor."
 
-TMP_PROJECT_PATH=/tmp/ros2cs_unity_project/$UNITY_VERSION
+TMP_PROJECT_PATH="/tmp/ros2cs_unity_project/$SAFE_UNITY_VERSION"
 # Create temp project
 if [ -d "$TMP_PROJECT_PATH" ]; then
     echo "Found existing temporary project for Unity $UNITY_VERSION."
-    rm -rf $TMP_PROJECT_PATH/Assets/*
+    rm -rf "$TMP_PROJECT_PATH/Assets"/*
 else
-  rm -rf $TMP_PROJECT_PATH
+  rm -rf "$TMP_PROJECT_PATH"
   echo "Creating Unity temporary project for Unity $UNITY_VERSION..."
-  $UNITY_PATH -createProject $TMP_PROJECT_PATH -batchmode -quit
+  "$UNITY_PATH" -createProject "$TMP_PROJECT_PATH" -batchmode -quit
 fi
 
 # Copy asset
@@ -103,12 +105,12 @@ cp -r "$INPUT_ASSET" "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME"
 
 # Creating asset
 echo "Saving unitypackage '$OUTPUT_DIR/$PACKAGE_NAME.unitypackage'..."
-mkdir -p $OUTPUT_DIR
-$UNITY_PATH -projectPath "$TMP_PROJECT_PATH" -exportPackage "Assets/$PACKAGE_NAME" "$OUTPUT_DIR/$PACKAGE_NAME.unitypackage" -batchmode -quit
+mkdir -p "$OUTPUT_DIR"
+"$UNITY_PATH" -projectPath "$TMP_PROJECT_PATH" -exportPackage "Assets/$PACKAGE_NAME" "$OUTPUT_DIR/$PACKAGE_NAME.unitypackage" -batchmode -quit
 
 # Cleaning up
 echo "Cleaning up temporary project..."
-rm -rf $TMP_PROJECT_PATH/Assets/*
+rm -rf "$TMP_PROJECT_PATH/Assets"/*
 
 echo "Done!"
 

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -75,7 +75,19 @@ if [ ! -d "$INPUT_ASSET" ]; then
     exit 1
 fi
 
-UNITY_VERSION=$("$UNITY_PATH" -version | head -n 1)
+unity_version_from_path() {
+  local path="$1"
+  if [[ "$path" =~ /([0-9]{4}\.[0-9]+\.[0-9]+f?[0-9]*)/Editor/Unity$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+UNITY_VERSION=$(unity_version_from_path "$UNITY_PATH" || true)
+if [ -z "$UNITY_VERSION" ]; then
+  UNITY_VERSION=$("$UNITY_PATH" -version | head -n 1)
+fi
 SAFE_UNITY_VERSION=$(printf '%s' "$UNITY_VERSION" | tr -c 'A-Za-z0-9._-' '_')
 if [ -z "$SAFE_UNITY_VERSION" ]; then
     echo "Cannot derive a safe Unity version path from '$UNITY_VERSION'."
@@ -120,7 +132,13 @@ fi
 
 # Copy asset
 echo "Copying asset to export..."
-cp -r "$INPUT_ASSET" "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME"
+if command -v rsync >/dev/null 2>&1; then
+  mkdir -p "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME"
+  rsync --archive --delete "$INPUT_ASSET/" "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME/"
+else
+  rm -rf "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME"
+  cp -r "$INPUT_ASSET" "$TMP_PROJECT_PATH/Assets/$PACKAGE_NAME"
+fi
 
 # Creating asset
 echo "Saving unitypackage '$OUTPUT_DIR/$PACKAGE_NAME.unitypackage'..."

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -50,8 +50,10 @@ while [[ $# -gt 0 ]]; do
       exit 0
       shift # past argument
       ;;
-    *)    # unknown option
-      shift # past argument
+    *)
+      echo "Unknown option: $1"
+      display_usage
+      exit 1
       ;;
   esac
 done
@@ -70,6 +72,10 @@ fi
 
 UNITY_VERSION=$("$UNITY_PATH" -version | head -n 1)
 SAFE_UNITY_VERSION=$(echo "$UNITY_VERSION" | tr -c 'A-Za-z0-9._-' '_')
+if [ -z "$SAFE_UNITY_VERSION" ]; then
+    echo "Cannot derive a safe Unity version path from '$UNITY_VERSION'."
+    exit 1
+fi
 
 # Test if unity editor is valid
 if [[ $UNITY_VERSION =~ ^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$ ]]; then
@@ -94,7 +100,6 @@ if [ -d "$TMP_PROJECT_PATH" ]; then
     echo "Found existing temporary project for Unity $UNITY_VERSION."
     rm -rf "$TMP_PROJECT_PATH/Assets"/*
 else
-  rm -rf "$TMP_PROJECT_PATH"
   echo "Creating Unity temporary project for Unity $UNITY_VERSION..."
   "$UNITY_PATH" -createProject "$TMP_PROJECT_PATH" -batchmode -quit
 fi
@@ -113,4 +118,3 @@ echo "Cleaning up temporary project..."
 rm -rf "$TMP_PROJECT_PATH/Assets"/*
 
 echo "Done!"
-

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -76,7 +76,7 @@ if [ ! -d "$INPUT_ASSET" ]; then
 fi
 
 UNITY_VERSION=$("$UNITY_PATH" -version | head -n 1)
-SAFE_UNITY_VERSION=$(echo "$UNITY_VERSION" | tr -c 'A-Za-z0-9._-' '_')
+SAFE_UNITY_VERSION=$(printf '%s' "$UNITY_VERSION" | tr -c 'A-Za-z0-9._-' '_')
 if [ -z "$SAFE_UNITY_VERSION" ]; then
     echo "Cannot derive a safe Unity version path from '$UNITY_VERSION'."
     exit 1

--- a/create_unity_package.sh
+++ b/create_unity_package.sh
@@ -7,7 +7,7 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 display_usage() {
   echo "This script creates a temporary Unity project in '/tmp' directory, copy input asset and makes an unity package out of it. Valid Unity license is required."
   echo ""
-  echo "Usage:" 
+  echo "Usage:"
   echo "create_unity_package.sh -u <UNITY_PATH> -i [INPUT_ASSET] -p [PACKAGE_NAME] -o [OUTPUT_DIR]"
   echo ""
   echo "UNITY_PATH - Unity editor executable path"
@@ -48,7 +48,6 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       display_usage
       exit 0
-      shift # past argument
       ;;
     *)
       echo "Unknown option: $1"
@@ -78,7 +77,7 @@ if [ -z "$SAFE_UNITY_VERSION" ]; then
 fi
 
 # Test if unity editor is valid
-if [[ $UNITY_VERSION =~ ^[0-9]{4}\.[0-9]*\.[0-9]*[f]?[0-9]*$ ]]; then
+if [[ $UNITY_VERSION =~ ^[0-9]{4}\.[0-9]*\.[0-9]*f?[0-9]*$ ]]; then
     echo "Unity editor confirmed."
 else
     while true; do
@@ -94,11 +93,13 @@ fi
 
 echo "Using \"${UNITY_PATH}\" editor."
 
-TMP_PROJECT_PATH="/tmp/ros2cs_unity_project/$SAFE_UNITY_VERSION"
+TMP_ROOT="${TMPDIR:-/tmp}"
+TMP_PROJECT_PATH="$TMP_ROOT/ros2cs_unity_project/$SAFE_UNITY_VERSION"
 # Create temp project
 if [ -d "$TMP_PROJECT_PATH" ]; then
     echo "Found existing temporary project for Unity $UNITY_VERSION."
-    rm -rf "$TMP_PROJECT_PATH/Assets"/*
+    rm -rf "$TMP_PROJECT_PATH/Assets"
+    mkdir -p "$TMP_PROJECT_PATH/Assets"
 else
   echo "Creating Unity temporary project for Unity $UNITY_VERSION..."
   "$UNITY_PATH" -createProject "$TMP_PROJECT_PATH" -batchmode -quit
@@ -115,6 +116,7 @@ mkdir -p "$OUTPUT_DIR"
 
 # Cleaning up
 echo "Cleaning up temporary project..."
-rm -rf "$TMP_PROJECT_PATH/Assets"/*
+rm -rf "$TMP_PROJECT_PATH/Assets"
+mkdir -p "$TMP_PROJECT_PATH/Assets"
 
 echo "Done!"

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -6,6 +6,7 @@ Set-StrictMode -Version Latest
 # Modifications by Jianbin Liu:
 # - Added fail-fast plugin deployment with an explicit install root.
 # - Made optional standalone-library copies non-fatal when the source directory is absent.
+# - Replaced PowerShell -Exclude directory filtering with explicit file-name predicates.
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $pluginDir = if ($args.Count -gt 0) { $args[0] } else { "" }
@@ -35,21 +36,40 @@ if ([string]::IsNullOrEmpty($pluginDir))
 
 if (Test-Path -Path $pluginDir) {
     Write-Host "Copying plugins to: '$pluginDir' ..."
-    Get-ChildItem "$installRoot\lib\dotnet\" -File -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
+    $dotnetDir = Join-Path -Path $installRoot -ChildPath "lib\dotnet"
+    if (-not (Test-Path -LiteralPath $dotnetDir)) {
+        throw "Managed plugin source directory does not exist: $dotnetDir"
+    }
+    Get-ChildItem -LiteralPath $dotnetDir -File |
+        Where-Object { $_.Name -notlike "*.pdb" } |
+        Copy-Item -Destination ${pluginDir} -Force
+
     Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
-    if(-not (Test-Path -Path $pluginDir\Windows\x86_64\)) {
-        New-Item -ItemType Directory -Force -Path ${pluginDir}\Windows\x86_64\ | Out-Null
+    $windowsPluginDir = Join-Path -Path $pluginDir -ChildPath "Windows\x86_64"
+    if(-not (Test-Path -LiteralPath $windowsPluginDir)) {
+        New-Item -ItemType Directory -Force -Path $windowsPluginDir | Out-Null
     }
-    Write-Host "Copying libraries to: '$pluginDir\Windows\x86_64\' ..."
-    Get-ChildItem "$installRoot\bin\" -File -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
+    Write-Host "Copying libraries to: '$windowsPluginDir' ..."
+    $binDir = Join-Path -Path $installRoot -ChildPath "bin"
+    if (-not (Test-Path -LiteralPath $binDir)) {
+        throw "Native library source directory does not exist: $binDir"
+    }
+    Get-ChildItem -LiteralPath $binDir -File |
+        Where-Object { $_.Name -notlike "*_py.dll" -and $_.Name -notlike "*_python.dll" } |
+        Copy-Item -Destination $windowsPluginDir -Force
+
     # Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
-    if(Test-Path -Path "$installRoot\standalone\") {
-        Copy-Item -Path "$installRoot\standalone\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
+    $standaloneDir = Join-Path -Path $installRoot -ChildPath "standalone"
+    if(Test-Path -LiteralPath $standaloneDir) {
+        Get-ChildItem -LiteralPath $standaloneDir -File -Filter "*.dll" |
+            Copy-Item -Destination $windowsPluginDir -Force
     }
-    if(Test-Path -Path "$installRoot\resources\") {
-        Copy-Item -Path "$installRoot\resources\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
+    $resourcesDir = Join-Path -Path $installRoot -ChildPath "resources"
+    if(Test-Path -LiteralPath $resourcesDir) {
+        Get-ChildItem -LiteralPath $resourcesDir -File -Filter "*.dll" |
+            Copy-Item -Destination $windowsPluginDir -Force
     }
-    Write-Host "Libraries copied to '${pluginDir}\Windows\x86_64\'" -ForegroundColor Green
+    Write-Host "Libraries copied to '$windowsPluginDir'" -ForegroundColor Green
 } else {
     Write-Host "Plugins directory: '$pluginDir' doesn't exist. Please create it first manually." -ForegroundColor Red
     exit 1

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -69,15 +69,13 @@ function Copy-FilesWithRobocopy {
     if (-not (Test-Path -LiteralPath $Source)) {
         throw "Copy source directory does not exist: $Source"
     }
-    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-
     $robocopyArgs = @($Source, $Destination)
     $robocopyArgs += $Includes
     if ($Excludes.Count -gt 0) {
         $robocopyArgs += "/XF"
         $robocopyArgs += $Excludes
     }
-    $robocopyArgs += @("/R:2", "/W:1", "/NP", "/NFL", "/NDL", "/NJH", "/NJS")
+    $robocopyArgs += @("/R:1", "/W:0", "/NP", "/NFL", "/NDL", "/NJH", "/NJS")
 
     & robocopy @robocopyArgs
     $robocopyExitCode = $LASTEXITCODE
@@ -132,9 +130,6 @@ try {
 
         Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
         $windowsPluginDir = Join-Path -Path $pluginDir -ChildPath "Windows\x86_64"
-        if(-not (Test-Path -LiteralPath $windowsPluginDir)) {
-            New-Item -ItemType Directory -Force -Path $windowsPluginDir | Out-Null
-        }
         Write-Host "Copying libraries to: '$windowsPluginDir' ..."
         $binDir = Join-Path -Path $installRoot -ChildPath "bin"
         if (-not (Test-Path -LiteralPath $binDir)) {

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -1,6 +1,12 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added fail-fast plugin deployment with an explicit install root.
+# - Made optional standalone-library copies non-fatal when the source directory is absent.
+
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $pluginDir = if ($args.Count -gt 0) { $args[0] } else { "" }
 $installRoot = if ($args.Count -gt 1) { $args[1] } else { Join-Path -Path $scriptPath -ChildPath "install" }
@@ -36,6 +42,7 @@ if (Test-Path -Path $pluginDir) {
     }
     Write-Host "Copying libraries to: '$pluginDir\Windows\x86_64\' ..."
     Get-ChildItem "$installRoot\bin\" -File -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
+    # Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
     if(Test-Path -Path "$installRoot\standalone\") {
         Copy-Item -Path "$installRoot\standalone\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
     }

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -7,10 +7,87 @@ Set-StrictMode -Version Latest
 # - Added fail-fast plugin deployment with an explicit install root.
 # - Made optional standalone-library copies non-fatal when the source directory is absent.
 # - Replaced PowerShell -Exclude directory filtering with explicit file-name predicates.
+# - Added deployment timing and required managed/native file checks.
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $pluginDir = if ($args.Count -gt 0) { $args[0] } else { "" }
 $installRoot = if ($args.Count -gt 1) { $args[1] } else { Join-Path -Path $scriptPath -ChildPath "install" }
+$script:TimingRows = New-Object System.Collections.Generic.List[object]
+$script:TotalStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+function Format-Duration {
+    param([Parameter(Mandatory=$true)][TimeSpan]$Elapsed)
+    return "{0:mm\:ss\.fff}" -f $Elapsed
+}
+
+function Invoke-Timed {
+    param(
+        [Parameter(Mandatory=$true)][string]$Name,
+        [Parameter(Mandatory=$true)][scriptblock]$Action
+    )
+
+    $watch = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        & $Action
+    }
+    finally {
+        $watch.Stop()
+        $script:TimingRows.Add([pscustomobject]@{
+            Phase = $Name
+            Elapsed = $watch.Elapsed
+        }) | Out-Null
+    }
+}
+
+function Write-TimingSummary {
+    if ($script:TotalStopwatch.IsRunning) {
+        $script:TotalStopwatch.Stop()
+    }
+
+    Write-Host ""
+    Write-Host "Ros2ForUnity plugin deployment timing summary:" -ForegroundColor Cyan
+    foreach ($row in $script:TimingRows) {
+        Write-Host ("  {0,-28} {1}" -f $row.Phase, (Format-Duration $row.Elapsed))
+    }
+    Write-Host ("  {0,-28} {1}" -f "total", (Format-Duration $script:TotalStopwatch.Elapsed))
+}
+
+function Copy-FilesWithRobocopy {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Destination,
+        [string[]]$Includes = @("*.*"),
+        [string[]]$Excludes = @()
+    )
+
+    if (-not (Test-Path -LiteralPath $Source)) {
+        throw "Copy source directory does not exist: $Source"
+    }
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+
+    $robocopyArgs = @($Source, $Destination)
+    $robocopyArgs += $Includes
+    if ($Excludes.Count -gt 0) {
+        $robocopyArgs += "/XF"
+        $robocopyArgs += $Excludes
+    }
+    $robocopyArgs += @("/R:2", "/W:1", "/NP", "/NFL", "/NDL", "/NJH", "/NJS")
+
+    & robocopy @robocopyArgs
+    $robocopyExitCode = $LASTEXITCODE
+    # Robocopy success/informational codes are 0-7.
+    if ($robocopyExitCode -gt 7) {
+        throw "robocopy failed from '$Source' to '$Destination' with exit code $robocopyExitCode"
+    }
+    $global:LASTEXITCODE = 0
+}
+
+function Assert-RequiredFile {
+    param([Parameter(Mandatory=$true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Required deployed file is missing: $Path"
+    }
+}
 
 function Print-Help {
 "
@@ -34,43 +111,67 @@ if ([string]::IsNullOrEmpty($pluginDir))
     exit 1
 }
 
-if (Test-Path -Path $pluginDir) {
-    Write-Host "Copying plugins to: '$pluginDir' ..."
-    $dotnetDir = Join-Path -Path $installRoot -ChildPath "lib\dotnet"
-    if (-not (Test-Path -LiteralPath $dotnetDir)) {
-        throw "Managed plugin source directory does not exist: $dotnetDir"
-    }
-    Get-ChildItem -LiteralPath $dotnetDir -File |
-        Where-Object { $_.Name -notlike "*.pdb" } |
-        Copy-Item -Destination ${pluginDir} -Force
+try {
+    if (Test-Path -Path $pluginDir) {
+        Write-Host "Copying plugins to: '$pluginDir' ..."
+        $dotnetDir = Join-Path -Path $installRoot -ChildPath "lib\dotnet"
+        if (-not (Test-Path -LiteralPath $dotnetDir)) {
+            throw "Managed plugin source directory does not exist: $dotnetDir"
+        }
+        Invoke-Timed "managed DLL deploy" {
+            Copy-FilesWithRobocopy -Source $dotnetDir -Destination $pluginDir -Includes @("*.*") -Excludes @("*.pdb")
+        }
+        Assert-RequiredFile (Join-Path -Path $pluginDir -ChildPath "ros2cs_common.dll")
+        Assert-RequiredFile (Join-Path -Path $pluginDir -ChildPath "ros2cs_core.dll")
 
-    Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
-    $windowsPluginDir = Join-Path -Path $pluginDir -ChildPath "Windows\x86_64"
-    if(-not (Test-Path -LiteralPath $windowsPluginDir)) {
-        New-Item -ItemType Directory -Force -Path $windowsPluginDir | Out-Null
-    }
-    Write-Host "Copying libraries to: '$windowsPluginDir' ..."
-    $binDir = Join-Path -Path $installRoot -ChildPath "bin"
-    if (-not (Test-Path -LiteralPath $binDir)) {
-        throw "Native library source directory does not exist: $binDir"
-    }
-    Get-ChildItem -LiteralPath $binDir -File |
-        Where-Object { $_.Name -notlike "*_py.dll" -and $_.Name -notlike "*_python.dll" } |
-        Copy-Item -Destination $windowsPluginDir -Force
+        Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
+        $windowsPluginDir = Join-Path -Path $pluginDir -ChildPath "Windows\x86_64"
+        if(-not (Test-Path -LiteralPath $windowsPluginDir)) {
+            New-Item -ItemType Directory -Force -Path $windowsPluginDir | Out-Null
+        }
+        Write-Host "Copying libraries to: '$windowsPluginDir' ..."
+        $binDir = Join-Path -Path $installRoot -ChildPath "bin"
+        if (-not (Test-Path -LiteralPath $binDir)) {
+            throw "Native library source directory does not exist: $binDir"
+        }
+        Invoke-Timed "native bin DLL deploy" {
+            Copy-FilesWithRobocopy -Source $binDir -Destination $windowsPluginDir -Includes @("*.*") -Excludes @("*_py.dll", "*_python.dll")
+        }
 
-    # Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
-    $standaloneDir = Join-Path -Path $installRoot -ChildPath "standalone"
-    if(Test-Path -LiteralPath $standaloneDir) {
-        Get-ChildItem -LiteralPath $standaloneDir -File -Filter "*.dll" |
-            Copy-Item -Destination $windowsPluginDir -Force
+        # Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
+        $standaloneDir = Join-Path -Path $installRoot -ChildPath "standalone"
+        $hasStandaloneDir = Test-Path -LiteralPath $standaloneDir
+        if($hasStandaloneDir) {
+            Invoke-Timed "standalone DLL deploy" {
+                Copy-FilesWithRobocopy -Source $standaloneDir -Destination $windowsPluginDir -Includes @("*.dll")
+            }
+        }
+        $resourcesDir = Join-Path -Path $installRoot -ChildPath "resources"
+        $hasResourcesDir = Test-Path -LiteralPath $resourcesDir
+        if($hasResourcesDir) {
+            Invoke-Timed "resource DLL deploy" {
+                Copy-FilesWithRobocopy -Source $resourcesDir -Destination $windowsPluginDir -Includes @("*.dll")
+            }
+        }
+
+        if ($hasStandaloneDir -or $hasResourcesDir -or (Test-Path -LiteralPath (Join-Path -Path $binDir -ChildPath "rcl.dll"))) {
+            Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "rcl.dll")
+            Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "rmw_implementation.dll")
+            $yamlDll = Join-Path -Path $windowsPluginDir -ChildPath "yaml.dll"
+            $yamlCppDll = Join-Path -Path $windowsPluginDir -ChildPath "yaml-cpp.dll"
+            if (-not ((Test-Path -LiteralPath $yamlDll) -or (Test-Path -LiteralPath $yamlCppDll))) {
+                throw "Required deployed YAML runtime is missing: expected yaml.dll or yaml-cpp.dll under $windowsPluginDir"
+            }
+        }
+
+        $managedCount = (Get-ChildItem -LiteralPath $pluginDir -File | Measure-Object).Count
+        $nativeCount = (Get-ChildItem -LiteralPath $windowsPluginDir -File | Measure-Object).Count
+        Write-Host "Libraries copied to '$windowsPluginDir'" -ForegroundColor Green
+        Write-Host "Deployment file counts: managed=$managedCount native=$nativeCount" -ForegroundColor Green
+    } else {
+        throw "Plugins directory: '$pluginDir' doesn't exist. Please create it first manually."
     }
-    $resourcesDir = Join-Path -Path $installRoot -ChildPath "resources"
-    if(Test-Path -LiteralPath $resourcesDir) {
-        Get-ChildItem -LiteralPath $resourcesDir -File -Filter "*.dll" |
-            Copy-Item -Destination $windowsPluginDir -Force
-    }
-    Write-Host "Libraries copied to '$windowsPluginDir'" -ForegroundColor Green
-} else {
-    Write-Host "Plugins directory: '$pluginDir' doesn't exist. Please create it first manually." -ForegroundColor Red
-    exit 1
+}
+finally {
+    Write-TimingSummary
 }

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -295,11 +295,18 @@ try {
 
         $assetRoot = Split-Path -Parent $pluginDir
         $shareDestination = Join-Path -Path $windowsPluginDir -ChildPath "share"
+        $assetInstallRoot = Split-Path -Parent $assetRoot
+        $legacyNestedStreamingAssets = Join-Path -Path $assetRoot -ChildPath "StreamingAssets"
+        $streamingAssetsShareDestination = Join-Path -Path $assetInstallRoot -ChildPath "StreamingAssets\Ros2ForUnity\share"
+        if (Test-Path -LiteralPath $legacyNestedStreamingAssets) {
+            Remove-Item -LiteralPath $legacyNestedStreamingAssets -Recurse -Force
+        }
         foreach ($ros2Root in Find-RosRootCandidates) {
             $ros2Share = Join-Path -Path $ros2Root -ChildPath "share"
             if (Test-Path -LiteralPath $ros2Share) {
                 Invoke-Timed "ROS2 runtime share deploy" {
                     Copy-RosRuntimeShareClosure -SourceShare $ros2Share -DestinationShare $shareDestination
+                    Copy-RosRuntimeShareClosure -SourceShare $ros2Share -DestinationShare $streamingAssetsShareDestination
                 }
                 break
             }
@@ -336,6 +343,9 @@ try {
             Assert-RequiredFile (Join-Path -Path $shareDestination -ChildPath "ament_index\resource_index\packages\rosidl_buffer_backend")
             Assert-RequiredFile (Join-Path -Path $shareDestination -ChildPath "ament_index\resource_index\packages\rmw_implementation")
             Assert-RequiredFile (Join-Path -Path $shareDestination -ChildPath "ament_index\resource_index\rmw_typesupport\rmw_fastrtps_cpp")
+            Assert-RequiredFile (Join-Path -Path $streamingAssetsShareDestination -ChildPath "ament_index\resource_index\packages\rosidl_buffer_backend")
+            Assert-RequiredFile (Join-Path -Path $streamingAssetsShareDestination -ChildPath "ament_index\resource_index\packages\rmw_implementation")
+            Assert-RequiredFile (Join-Path -Path $streamingAssetsShareDestination -ChildPath "ament_index\resource_index\rmw_typesupport\rmw_fastrtps_cpp")
             $yamlDll = Join-Path -Path $windowsPluginDir -ChildPath "yaml.dll"
             $yamlCppDll = Join-Path -Path $windowsPluginDir -ChildPath "yaml-cpp.dll"
             if (-not ((Test-Path -LiteralPath $yamlDll) -or (Test-Path -LiteralPath $yamlCppDll))) {

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -3,13 +3,15 @@ Set-StrictMode -Version Latest
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $pluginDir = if ($args.Count -gt 0) { $args[0] } else { "" }
+$installRoot = if ($args.Count -gt 1) { $args[1] } else { Join-Path -Path $scriptPath -ChildPath "install" }
 
 function Print-Help {
 "
 Usage: 
-deploy_unity_plugins.ps1 <PLUGINS_DIR>
+deploy_unity_plugins.ps1 <PLUGINS_DIR> [INSTALL_ROOT]
 
 PLUGINS_DIR - Ros2ForUnity/Plugins.
+INSTALL_ROOT - ros2cs install prefix. Defaults to this repository's install directory.
 "
 }
 
@@ -21,18 +23,18 @@ if (([string]::IsNullOrEmpty($pluginDir)) -Or $pluginDir -eq "--help" -Or $plugi
 
 if (Test-Path -Path $pluginDir) {
     Write-Host "Copying plugins to to: '$pluginDir' ..."
-    Get-ChildItem "$scriptPath\install\lib\dotnet\" -Recurse -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
+    Get-ChildItem "$installRoot\lib\dotnet\" -Recurse -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
     Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
     if(-not (Test-Path -Path $pluginDir\Windows\x86_64\)) {
         mkdir ${pluginDir}\Windows\x86_64\
     }
     Write-Host "Copying libraries to: '$pluginDir\Windows\x86_64\' ..."
-    Get-ChildItem "$scriptPath\install\bin\" -Recurse -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
-    if(Test-Path -Path "$scriptPath\install\standalone\") {
-        Copy-Item -Path "$scriptPath\install\standalone\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
+    Get-ChildItem "$installRoot\bin\" -Recurse -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
+    if(Test-Path -Path "$installRoot\standalone\") {
+        Copy-Item -Path "$installRoot\standalone\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
     }
-    if(Test-Path -Path "$scriptPath\install\resources\") {
-        Copy-Item -Path "$scriptPath\install\resources\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
+    if(Test-Path -Path "$installRoot\resources\") {
+        Copy-Item -Path "$installRoot\resources\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
     }
     Write-Host "Libraries copied to '${pluginDir}\Windows\x86_64\'" -ForegroundColor Green
 } else {

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -86,11 +86,149 @@ function Copy-FilesWithRobocopy {
     $global:LASTEXITCODE = 0
 }
 
+function Copy-DirectoryTreeWithRobocopy {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Destination
+    )
+
+    if (-not (Test-Path -LiteralPath $Source)) {
+        throw "Copy source directory does not exist: $Source"
+    }
+
+    & robocopy $Source $Destination /E /R:1 /W:0 /NP /NFL /NDL /NJH /NJS
+    $robocopyExitCode = $LASTEXITCODE
+    # Robocopy success/informational codes are 0-7.
+    if ($robocopyExitCode -gt 7) {
+        throw "robocopy failed from '$Source' to '$Destination' with exit code $robocopyExitCode"
+    }
+    $global:LASTEXITCODE = 0
+}
+
+function Copy-FilePreservingRelativePath {
+    param(
+        [Parameter(Mandatory=$true)][string]$SourceRoot,
+        [Parameter(Mandatory=$true)][string]$DestinationRoot,
+        [Parameter(Mandatory=$true)][string]$RelativePath
+    )
+
+    $source = Join-Path -Path $SourceRoot -ChildPath $RelativePath
+    if (-not (Test-Path -LiteralPath $source)) {
+        return
+    }
+
+    $destination = Join-Path -Path $DestinationRoot -ChildPath $RelativePath
+    $destinationDir = Split-Path -Parent $destination
+    New-Item -ItemType Directory -Path $destinationDir -Force | Out-Null
+    Copy-Item -LiteralPath $source -Destination $destination -Force
+}
+
+function Copy-RosRuntimeShareClosure {
+    param(
+        [Parameter(Mandatory=$true)][string]$SourceShare,
+        [Parameter(Mandatory=$true)][string]$DestinationShare
+    )
+
+    $runtimePackages = @(
+        "ament_index_cpp",
+        "fastcdr",
+        "fastdds",
+        "foonathan_memory_vendor",
+        "rcpputils",
+        "rcutils",
+        "rmw",
+        "rmw_dds_common",
+        "rmw_fastrtps_cpp",
+        "rmw_fastrtps_shared_cpp",
+        "rmw_implementation",
+        "rmw_implementation_cmake",
+        "rmw_security_common",
+        "rosidl_buffer_backend",
+        "rosidl_dynamic_typesupport",
+        "rosidl_dynamic_typesupport_fastrtps",
+        "rosidl_runtime_c",
+        "rosidl_runtime_cpp",
+        "rosidl_typesupport_c",
+        "rosidl_typesupport_cpp",
+        "rosidl_typesupport_fastrtps_c",
+        "rosidl_typesupport_fastrtps_cpp",
+        "rosidl_typesupport_introspection_c",
+        "rosidl_typesupport_introspection_cpp"
+    )
+    $resourceIndexes = @(
+        "packages",
+        "package_run_dependencies",
+        "parent_prefix_path",
+        "rmw_output_patterns",
+        "rmw_output_prefixes",
+        "rmw_typesupport",
+        "rmw_typesupport_c",
+        "rmw_typesupport_cpp",
+        "rosidl_typesupport_c",
+        "rosidl_typesupport_cpp"
+    )
+
+    foreach ($packageName in $runtimePackages) {
+        foreach ($resourceIndex in $resourceIndexes) {
+            Copy-FilePreservingRelativePath `
+                -SourceRoot $SourceShare `
+                -DestinationRoot $DestinationShare `
+                -RelativePath (Join-Path -Path "ament_index\resource_index\$resourceIndex" -ChildPath $packageName)
+        }
+    }
+}
+
 function Assert-RequiredFile {
     param([Parameter(Mandatory=$true)][string]$Path)
     if (-not (Test-Path -LiteralPath $Path)) {
         throw "Required deployed file is missing: $Path"
     }
+}
+
+function Find-RosRuntimeDll {
+    param([Parameter(Mandatory=$true)][string]$FileName)
+
+    $candidateDirs = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($env:ROS2_ROOT)) {
+        $candidateDirs.Add((Join-Path -Path $env:ROS2_ROOT -ChildPath "bin")) | Out-Null
+    }
+    foreach ($pathDir in ($env:PATH -split [System.IO.Path]::PathSeparator)) {
+        if (-not [string]::IsNullOrWhiteSpace($pathDir)) {
+            $candidateDirs.Add($pathDir) | Out-Null
+        }
+    }
+
+    foreach ($dir in ($candidateDirs | Select-Object -Unique)) {
+        $candidate = Join-Path -Path $dir -ChildPath $FileName
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function Find-RosRootCandidates {
+    $roots = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($env:ROS2_ROOT)) {
+        $roots.Add($env:ROS2_ROOT) | Out-Null
+    }
+
+    foreach ($pathDir in ($env:PATH -split [System.IO.Path]::PathSeparator)) {
+        if ([string]::IsNullOrWhiteSpace($pathDir)) {
+            continue
+        }
+        if ((Split-Path -Leaf $pathDir) -ne "bin") {
+            continue
+        }
+
+        $root = Split-Path -Parent $pathDir
+        if (Test-Path -LiteralPath (Join-Path -Path $root -ChildPath "share\ament_index")) {
+            $roots.Add($root) | Out-Null
+        }
+    }
+
+    return $roots | Select-Object -Unique
 }
 
 function Print-Help {
@@ -155,9 +293,49 @@ try {
             }
         }
 
+        $assetRoot = Split-Path -Parent $pluginDir
+        $shareDestination = Join-Path -Path $windowsPluginDir -ChildPath "share"
+        foreach ($ros2Root in Find-RosRootCandidates) {
+            $ros2Share = Join-Path -Path $ros2Root -ChildPath "share"
+            if (Test-Path -LiteralPath $ros2Share) {
+                Invoke-Timed "ROS2 runtime share deploy" {
+                    Copy-RosRuntimeShareClosure -SourceShare $ros2Share -DestinationShare $shareDestination
+                }
+                break
+            }
+        }
+
+        $rosRootRuntimeDlls = @(
+            "class_loader.dll",
+            "fastdds-3.6.dll",
+            "rcl_logging_implementation.dll",
+            "rosidl_buffer_backend_registry.dll"
+        )
+        $rosRootRuntimeSources = @()
+        foreach ($dllName in $rosRootRuntimeDlls) {
+            $runtimeDll = Find-RosRuntimeDll $dllName
+            if ($null -ne $runtimeDll) {
+                $rosRootRuntimeSources += $runtimeDll
+            }
+        }
+        if ($rosRootRuntimeSources.Count -gt 0) {
+            Invoke-Timed "ROS2 root runtime DLL deploy" {
+                foreach ($runtimeDll in $rosRootRuntimeSources) {
+                    Copy-Item -LiteralPath $runtimeDll -Destination $windowsPluginDir -Force
+                }
+            }
+        }
+
         if ($hasStandaloneDir -or $hasResourcesDir -or (Test-Path -LiteralPath (Join-Path -Path $binDir -ChildPath "rcl.dll"))) {
             Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "rcl.dll")
+            Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "class_loader.dll")
+            Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "fastdds-3.6.dll")
             Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "rmw_implementation.dll")
+            Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "rosidl_buffer_backend_registry.dll")
+            Assert-RequiredFile (Join-Path -Path $windowsPluginDir -ChildPath "rcl_logging_implementation.dll")
+            Assert-RequiredFile (Join-Path -Path $shareDestination -ChildPath "ament_index\resource_index\packages\rosidl_buffer_backend")
+            Assert-RequiredFile (Join-Path -Path $shareDestination -ChildPath "ament_index\resource_index\packages\rmw_implementation")
+            Assert-RequiredFile (Join-Path -Path $shareDestination -ChildPath "ament_index\resource_index\rmw_typesupport\rmw_fastrtps_cpp")
             $yamlDll = Join-Path -Path $windowsPluginDir -ChildPath "yaml.dll"
             $yamlCppDll = Join-Path -Path $windowsPluginDir -ChildPath "yaml-cpp.dll"
             if (-not ((Test-Path -LiteralPath $yamlDll) -or (Test-Path -LiteralPath $yamlCppDll))) {

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -1,6 +1,3 @@
-$ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
-
 # Modifications Copyright (c) 2026 Jianbin Liu.
 #
 # Modifications by Jianbin Liu:
@@ -9,9 +6,18 @@ Set-StrictMode -Version Latest
 # - Replaced PowerShell -Exclude directory filtering with explicit file-name predicates.
 # - Added deployment timing and required managed/native file checks.
 
-$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
-$pluginDir = if ($args.Count -gt 0) { $args[0] } else { "" }
-$installRoot = if ($args.Count -gt 1) { $args[1] } else { Join-Path -Path $scriptPath -ChildPath "install" }
+Param (
+    [Parameter(Mandatory=$false, Position=0)][string]$pluginDir = "",
+    [Parameter(Mandatory=$false, Position=1)][string]$installRoot = ""
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
+if ([string]::IsNullOrEmpty($installRoot)) {
+    $installRoot = Join-Path -Path $scriptPath -ChildPath "install"
+}
 $script:TimingRows = New-Object System.Collections.Generic.List[object]
 $script:TotalStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
@@ -112,7 +118,7 @@ if ([string]::IsNullOrEmpty($pluginDir))
 }
 
 try {
-    if (Test-Path -Path $pluginDir) {
+    if (Test-Path -LiteralPath $pluginDir) {
         Write-Host "Copying plugins to: '$pluginDir' ..."
         $dotnetDir = Join-Path -Path $installRoot -ChildPath "lib\dotnet"
         if (-not (Test-Path -LiteralPath $dotnetDir)) {

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -15,21 +15,27 @@ INSTALL_ROOT - ros2cs install prefix. Defaults to this repository's install dire
 "
 }
 
-if (([string]::IsNullOrEmpty($pluginDir)) -Or $pluginDir -eq "--help" -Or $pluginDir -eq "-h")
+if ($pluginDir -eq "--help" -Or $pluginDir -eq "-h")
+{
+    Print-Help
+    exit 0
+}
+
+if ([string]::IsNullOrEmpty($pluginDir))
 {
     Print-Help
     exit 1
 }
 
 if (Test-Path -Path $pluginDir) {
-    Write-Host "Copying plugins to to: '$pluginDir' ..."
-    Get-ChildItem "$installRoot\lib\dotnet\" -Recurse -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
+    Write-Host "Copying plugins to: '$pluginDir' ..."
+    Get-ChildItem "$installRoot\lib\dotnet\" -File -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
     Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
     if(-not (Test-Path -Path $pluginDir\Windows\x86_64\)) {
-        mkdir ${pluginDir}\Windows\x86_64\
+        New-Item -ItemType Directory -Force -Path ${pluginDir}\Windows\x86_64\ | Out-Null
     }
     Write-Host "Copying libraries to: '$pluginDir\Windows\x86_64\' ..."
-    Get-ChildItem "$installRoot\bin\" -Recurse -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
+    Get-ChildItem "$installRoot\bin\" -File -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
     if(Test-Path -Path "$installRoot\standalone\") {
         Copy-Item -Path "$installRoot\standalone\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
     }

--- a/deploy_unity_plugins.ps1
+++ b/deploy_unity_plugins.ps1
@@ -1,5 +1,8 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
-$pluginDir=$args[0]
+$pluginDir = if ($args.Count -gt 0) { $args[0] } else { "" }
 
 function Print-Help {
 "
@@ -10,30 +13,29 @@ PLUGINS_DIR - Ros2ForUnity/Plugins.
 "
 }
 
-if (([string]::IsNullOrEmpty($pluginDir)) -Or $args[0] -eq "--help" -Or $args[0] -eq "-h")
+if (([string]::IsNullOrEmpty($pluginDir)) -Or $pluginDir -eq "--help" -Or $pluginDir -eq "-h")
 {
     Print-Help
-    exit
+    exit 1
 }
 
 if (Test-Path -Path $pluginDir) {
     Write-Host "Copying plugins to to: '$pluginDir' ..."
-    Get-ChildItem $scriptPath\install\lib\dotnet\ -Recurse -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
+    Get-ChildItem "$scriptPath\install\lib\dotnet\" -Recurse -Exclude @('*.pdb') | Copy-Item -Destination ${pluginDir}
     Write-Host "Plugins copied to: '$pluginDir'" -ForegroundColor Green
     if(-not (Test-Path -Path $pluginDir\Windows\x86_64\)) {
         mkdir ${pluginDir}\Windows\x86_64\
     }
     Write-Host "Copying libraries to: '$pluginDir\Windows\x86_64\' ..."
-    Get-ChildItem $scriptPath\install\bin\ -Recurse -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
-    if(-not (Test-Path -Path $scriptPath\install\standalone\)) {
-        mkdir $scriptPath\install\standalone
+    Get-ChildItem "$scriptPath\install\bin\" -Recurse -Exclude @('*_py.dll', '*_python.dll') | Copy-Item -Destination ${pluginDir}\Windows\x86_64\
+    if(Test-Path -Path "$scriptPath\install\standalone\") {
+        Copy-Item -Path "$scriptPath\install\standalone\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
     }
-    (Copy-Item -Path $scriptPath\install\standalone\*.dll -Destination ${pluginDir}\Windows\x86_64\ 4>&1).Message
-    if(-not (Test-Path -Path $scriptPath\install\resources\)) {
-        mkdir $scriptPath\install\resources
+    if(Test-Path -Path "$scriptPath\install\resources\") {
+        Copy-Item -Path "$scriptPath\install\resources\*.dll" -Destination "${pluginDir}\Windows\x86_64\" -ErrorAction SilentlyContinue
     }
-    (Copy-Item -Path $scriptPath\install\resources\*.dll -Destination ${pluginDir}\Windows\x86_64\ 4>&1).Message
     Write-Host "Libraries copied to '${pluginDir}\Windows\x86_64\'" -ForegroundColor Green
 } else {
     Write-Host "Plugins directory: '$pluginDir' doesn't exist. Please create it first manually." -ForegroundColor Red
+    exit 1
 }

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -4,8 +4,16 @@ set -euo pipefail
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
-if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-  echo "Usage:" 
+if [ $# -gt 0 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ]; }; then
+  echo "Usage:"
+  echo "deploy_unity_plugins.sh <PLUGINS_DIR>"
+  echo ""
+  echo "PLUGINS_DIR - Ros2ForUnity/Plugins folder."
+  exit 0
+fi
+
+if [ $# -eq 0 ]; then
+  echo "Usage:"
   echo "deploy_unity_plugins.sh <PLUGINS_DIR>"
   echo ""
   echo "PLUGINS_DIR - Ros2ForUnity/Plugins folder."

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -12,12 +12,23 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 TIMING_NAMES=()
 TIMING_MS=()
-TOTAL_START_NS=$(date +%s%N)
+now_ns() {
+  if [ -n "${EPOCHREALTIME:-}" ]; then
+    local realtime="$EPOCHREALTIME"
+    local seconds="${realtime%%[.,]*}"
+    local micros="${realtime#*[.,]}"
+    printf '%s%06d000\n' "$seconds" "$((10#$micros))"
+  else
+    date +%s%N
+  fi
+}
+
+TOTAL_START_NS=$(now_ns)
 
 elapsed_ms() {
   local start_ns="$1"
   local end_ns
-  end_ns=$(date +%s%N)
+  end_ns=$(now_ns)
   echo $(((end_ns - start_ns) / 1000000))
 }
 
@@ -33,9 +44,9 @@ print_timing_summary() {
   echo "Ros2ForUnity plugin deployment timing summary:"
   local i
   for ((i = 0; i < ${#TIMING_NAMES[@]}; i++)); do
-    printf '  %-28s %9s\n' "${TIMING_NAMES[$i]}" "$(awk "BEGIN { printf \"%.3fs\", ${TIMING_MS[$i]} / 1000 }")"
+    printf '  %-28s %5d.%03ds\n' "${TIMING_NAMES[$i]}" "$((TIMING_MS[$i] / 1000))" "$((TIMING_MS[$i] % 1000))"
   done
-  printf '  %-28s %9s\n' "total" "$(awk "BEGIN { printf \"%.3fs\", $total_ms / 1000 }")"
+  printf '  %-28s %5d.%03ds\n' "total" "$((total_ms / 1000))" "$((total_ms % 1000))"
 }
 
 run_timed() {
@@ -43,7 +54,7 @@ run_timed() {
   shift
   local start_ns
   local status
-  start_ns=$(date +%s%N)
+  start_ns=$(now_ns)
   set +e
   "$@"
   status=$?
@@ -123,5 +134,5 @@ if [ -d "$installRoot/standalone" ] || [ -d "$installRoot/resources" ] || compge
 fi
 
 managed_count=$(find "${pluginDir}" -maxdepth 1 -type f | wc -l)
-native_count=$(find "${pluginDir}/Linux/x86_64/" -maxdepth 1 -type f | wc -l)
+native_count=$(find "${pluginDir}/Linux/x86_64/" -maxdepth 1 \( -type f -o -type l \) | wc -l)
 echo "Deployment file counts: managed=${managed_count} native=${native_count}"

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -85,7 +85,7 @@ fi
 pluginDir=$1
 
 mkdir -p "${pluginDir}/Linux/x86_64/"
-run_timed "managed DLL deploy" copy_find_batch "$SCRIPTPATH/install/lib/dotnet/" "${pluginDir}" -not -name "*.pdb" -type f
+run_timed "managed DLL deploy" copy_find_batch "$SCRIPTPATH/install/lib/dotnet/" "${pluginDir}" -type f -not -name "*.pdb"
 for required_managed in ros2cs_common.dll ros2cs_core.dll; do
   if [ ! -f "${pluginDir}/${required_managed}" ]; then
     echo "Required deployed managed file is missing: ${pluginDir}/${required_managed}" >&2
@@ -98,7 +98,7 @@ if [ -d "$SCRIPTPATH/install/standalone" ]; then
 fi
 run_timed "native lib deploy" copy_find_batch "$SCRIPTPATH/install/lib/" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -not -name "*_python.so"
 if [ -d "$SCRIPTPATH/install/resources" ]; then
-  run_timed "resource native deploy" copy_find_batch "$SCRIPTPATH/install/resources" "${pluginDir}/Linux/x86_64/" -name "*.so" \( -type f -o -type l \)
+  run_timed "resource native deploy" copy_find_batch "$SCRIPTPATH/install/resources" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -name "*.so"
 fi
 
 managed_count=$(find "${pluginDir}" -maxdepth 1 -type f | wc -l)

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
-SCRIPT=$(readlink -f $0)
-SCRIPTPATH=`dirname $SCRIPT`
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
 
-if [ $# -eq 0 ] || [ $1 = "-h" ] || [ $1 = "--help" ]; then
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Usage:" 
   echo "deploy_unity_plugins.sh <PLUGINS_DIR>"
   echo ""
@@ -13,8 +14,12 @@ fi
 
 pluginDir=$1
 
-mkdir -p  ${pluginDir}/Linux/x86_64/
-find install/lib/dotnet/ -maxdepth 1 -not -name "*.pdb" -type f -exec cp {} ${pluginDir} \;
-cp $SCRIPTPATH/install/standalone/* ${pluginDir}/Linux/x86_64/ 2>/dev/null
-find install/lib/ -maxdepth 1 -not -name "*_python.so" -type f -exec cp {} ${pluginDir}/Linux/x86_64/ \;
-cp $SCRIPTPATH/install/resources/*.so ${pluginDir}/Linux/x86_64/ 2>/dev/null
+mkdir -p "${pluginDir}/Linux/x86_64/"
+find "$SCRIPTPATH/install/lib/dotnet/" -maxdepth 1 -not -name "*.pdb" -type f -exec cp {} "${pluginDir}" \;
+if [ -d "$SCRIPTPATH/install/standalone" ]; then
+  find "$SCRIPTPATH/install/standalone" -maxdepth 1 -type f -exec cp {} "${pluginDir}/Linux/x86_64/" \;
+fi
+find "$SCRIPTPATH/install/lib/" -maxdepth 1 -not -name "*_python.so" -type f -exec cp {} "${pluginDir}/Linux/x86_64/" \;
+if [ -d "$SCRIPTPATH/install/resources" ]; then
+  find "$SCRIPTPATH/install/resources" -maxdepth 1 -name "*.so" -type f -exec cp {} "${pluginDir}/Linux/x86_64/" \;
+fi

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -4,11 +4,67 @@
 # Modifications by Jianbin Liu:
 # - Added fail-fast plugin deployment.
 # - Made optional standalone-library copies non-fatal when the source directory is absent.
+# - Added deployment timing and batched copy operations.
 
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
+TIMING_NAMES=()
+TIMING_MS=()
+TOTAL_START_NS=$(date +%s%N)
+
+elapsed_ms() {
+  local start_ns="$1"
+  local end_ns
+  end_ns=$(date +%s%N)
+  echo $(((end_ns - start_ns) / 1000000))
+}
+
+record_timing() {
+  TIMING_NAMES+=("$1")
+  TIMING_MS+=("$2")
+}
+
+print_timing_summary() {
+  local total_ms
+  total_ms=$(elapsed_ms "$TOTAL_START_NS")
+  echo ""
+  echo "Ros2ForUnity plugin deployment timing summary:"
+  local i
+  for ((i = 0; i < ${#TIMING_NAMES[@]}; i++)); do
+    printf '  %-28s %8.3fs\n' "${TIMING_NAMES[$i]}" "$(awk "BEGIN { print ${TIMING_MS[$i]} / 1000 }")"
+  done
+  printf '  %-28s %8.3fs\n' "total" "$(awk "BEGIN { print $total_ms / 1000 }")"
+}
+
+run_timed() {
+  local name="$1"
+  shift
+  local start_ns
+  local status
+  start_ns=$(date +%s%N)
+  set +e
+  "$@"
+  status=$?
+  set -e
+  record_timing "$name" "$(elapsed_ms "$start_ns")"
+  return "$status"
+}
+
+copy_find_batch() {
+  local source_dir="$1"
+  local destination_dir="$2"
+  shift 2
+  if [ ! -d "$source_dir" ]; then
+    echo "Copy source directory does not exist: $source_dir" >&2
+    return 1
+  fi
+  mkdir -p "$destination_dir"
+  find "$source_dir" -maxdepth 1 "$@" -exec cp -L -t "$destination_dir" {} +
+}
+
+trap print_timing_summary EXIT
 
 if [ $# -gt 0 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ]; }; then
   echo "Usage:"
@@ -29,12 +85,22 @@ fi
 pluginDir=$1
 
 mkdir -p "${pluginDir}/Linux/x86_64/"
-find "$SCRIPTPATH/install/lib/dotnet/" -maxdepth 1 -not -name "*.pdb" -type f -exec cp {} "${pluginDir}" \;
+run_timed "managed DLL deploy" copy_find_batch "$SCRIPTPATH/install/lib/dotnet/" "${pluginDir}" -not -name "*.pdb" -type f
+for required_managed in ros2cs_common.dll ros2cs_core.dll; do
+  if [ ! -f "${pluginDir}/${required_managed}" ]; then
+    echo "Required deployed managed file is missing: ${pluginDir}/${required_managed}" >&2
+    exit 1
+  fi
+done
 # Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
 if [ -d "$SCRIPTPATH/install/standalone" ]; then
-  find "$SCRIPTPATH/install/standalone" -maxdepth 1 \( -type f -o -type l \) -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
+  run_timed "standalone native deploy" copy_find_batch "$SCRIPTPATH/install/standalone" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \)
 fi
-find "$SCRIPTPATH/install/lib/" -maxdepth 1 \( -type f -o -type l \) -not -name "*_python.so" -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
+run_timed "native lib deploy" copy_find_batch "$SCRIPTPATH/install/lib/" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -not -name "*_python.so"
 if [ -d "$SCRIPTPATH/install/resources" ]; then
-  find "$SCRIPTPATH/install/resources" -maxdepth 1 -name "*.so" \( -type f -o -type l \) -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
+  run_timed "resource native deploy" copy_find_batch "$SCRIPTPATH/install/resources" "${pluginDir}/Linux/x86_64/" -name "*.so" \( -type f -o -type l \)
 fi
+
+managed_count=$(find "${pluginDir}" -maxdepth 1 -type f | wc -l)
+native_count=$(find "${pluginDir}/Linux/x86_64/" -maxdepth 1 -type f | wc -l)
+echo "Deployment file counts: managed=${managed_count} native=${native_count}"

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -17,9 +17,9 @@ pluginDir=$1
 mkdir -p "${pluginDir}/Linux/x86_64/"
 find "$SCRIPTPATH/install/lib/dotnet/" -maxdepth 1 -not -name "*.pdb" -type f -exec cp {} "${pluginDir}" \;
 if [ -d "$SCRIPTPATH/install/standalone" ]; then
-  find "$SCRIPTPATH/install/standalone" -maxdepth 1 -type f -exec cp {} "${pluginDir}/Linux/x86_64/" \;
+  find "$SCRIPTPATH/install/standalone" -maxdepth 1 \( -type f -o -type l \) -exec cp -a {} "${pluginDir}/Linux/x86_64/" \;
 fi
-find "$SCRIPTPATH/install/lib/" -maxdepth 1 -not -name "*_python.so" -type f -exec cp {} "${pluginDir}/Linux/x86_64/" \;
+find "$SCRIPTPATH/install/lib/" -maxdepth 1 \( -type f -o -type l \) -not -name "*_python.so" -exec cp -a {} "${pluginDir}/Linux/x86_64/" \;
 if [ -d "$SCRIPTPATH/install/resources" ]; then
-  find "$SCRIPTPATH/install/resources" -maxdepth 1 -name "*.so" -type f -exec cp {} "${pluginDir}/Linux/x86_64/" \;
+  find "$SCRIPTPATH/install/resources" -maxdepth 1 -name "*.so" \( -type f -o -type l \) -exec cp -a {} "${pluginDir}/Linux/x86_64/" \;
 fi

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -17,9 +17,9 @@ pluginDir=$1
 mkdir -p "${pluginDir}/Linux/x86_64/"
 find "$SCRIPTPATH/install/lib/dotnet/" -maxdepth 1 -not -name "*.pdb" -type f -exec cp {} "${pluginDir}" \;
 if [ -d "$SCRIPTPATH/install/standalone" ]; then
-  find "$SCRIPTPATH/install/standalone" -maxdepth 1 \( -type f -o -type l \) -exec cp -a {} "${pluginDir}/Linux/x86_64/" \;
+  find "$SCRIPTPATH/install/standalone" -maxdepth 1 \( -type f -o -type l \) -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
 fi
-find "$SCRIPTPATH/install/lib/" -maxdepth 1 \( -type f -o -type l \) -not -name "*_python.so" -exec cp -a {} "${pluginDir}/Linux/x86_64/" \;
+find "$SCRIPTPATH/install/lib/" -maxdepth 1 \( -type f -o -type l \) -not -name "*_python.so" -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
 if [ -d "$SCRIPTPATH/install/resources" ]; then
-  find "$SCRIPTPATH/install/resources" -maxdepth 1 -name "*.so" \( -type f -o -type l \) -exec cp -a {} "${pluginDir}/Linux/x86_64/" \;
+  find "$SCRIPTPATH/install/resources" -maxdepth 1 -name "*.so" \( -type f -o -type l \) -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
 fi

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -66,12 +66,26 @@ run_timed() {
 copy_find_batch() {
   local source_dir="$1"
   local destination_dir="$2"
+  local source_root
   shift 2
   if [ ! -d "$source_dir" ]; then
     echo "Copy source directory does not exist: $source_dir" >&2
     return 1
   fi
   mkdir -p "$destination_dir"
+  source_root="${source_dir%/}"
+  if command -v rsync > /dev/null 2>&1; then
+    local files=()
+    local file
+    while IFS= read -r -d '' file; do
+      files+=("${file#"$source_root"/}")
+    done < <(find "$source_root" -maxdepth 1 "$@" -printf '%p\0')
+    if [ ${#files[@]} -eq 0 ]; then
+      return 0
+    fi
+    printf '%s\0' "${files[@]}" | rsync -a --checksum --copy-links --from0 --files-from=- "$source_root/" "$destination_dir/"
+    return
+  fi
   find "$source_dir" -maxdepth 1 "$@" -exec cp -L -t "$destination_dir" {} +
 }
 

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added fail-fast plugin deployment.
+# - Made optional standalone-library copies non-fatal when the source directory is absent.
+
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
@@ -24,6 +30,7 @@ pluginDir=$1
 
 mkdir -p "${pluginDir}/Linux/x86_64/"
 find "$SCRIPTPATH/install/lib/dotnet/" -maxdepth 1 -not -name "*.pdb" -type f -exec cp {} "${pluginDir}" \;
+# Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
 if [ -d "$SCRIPTPATH/install/standalone" ]; then
   find "$SCRIPTPATH/install/standalone" -maxdepth 1 \( -type f -o -type l \) -exec cp -L {} "${pluginDir}/Linux/x86_64/" \;
 fi

--- a/deploy_unity_plugins.sh
+++ b/deploy_unity_plugins.sh
@@ -33,9 +33,9 @@ print_timing_summary() {
   echo "Ros2ForUnity plugin deployment timing summary:"
   local i
   for ((i = 0; i < ${#TIMING_NAMES[@]}; i++)); do
-    printf '  %-28s %8.3fs\n' "${TIMING_NAMES[$i]}" "$(awk "BEGIN { print ${TIMING_MS[$i]} / 1000 }")"
+    printf '  %-28s %9s\n' "${TIMING_NAMES[$i]}" "$(awk "BEGIN { printf \"%.3fs\", ${TIMING_MS[$i]} / 1000 }")"
   done
-  printf '  %-28s %8.3fs\n' "total" "$(awk "BEGIN { print $total_ms / 1000 }")"
+  printf '  %-28s %9s\n' "total" "$(awk "BEGIN { printf \"%.3fs\", $total_ms / 1000 }")"
 }
 
 run_timed() {
@@ -68,24 +68,36 @@ trap print_timing_summary EXIT
 
 if [ $# -gt 0 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ]; }; then
   echo "Usage:"
-  echo "deploy_unity_plugins.sh <PLUGINS_DIR>"
+  echo "deploy_unity_plugins.sh <PLUGINS_DIR> [INSTALL_ROOT]"
   echo ""
   echo "PLUGINS_DIR - Ros2ForUnity/Plugins folder."
+  echo "INSTALL_ROOT - ros2cs install root, default = '<script dir>/install'."
   exit 0
 fi
 
 if [ $# -eq 0 ]; then
   echo "Usage:"
-  echo "deploy_unity_plugins.sh <PLUGINS_DIR>"
+  echo "deploy_unity_plugins.sh <PLUGINS_DIR> [INSTALL_ROOT]"
   echo ""
   echo "PLUGINS_DIR - Ros2ForUnity/Plugins folder."
+  echo "INSTALL_ROOT - ros2cs install root, default = '<script dir>/install'."
   exit 1
 fi
 
 pluginDir=$1
+installRoot=${2:-"$SCRIPTPATH/install"}
+
+require_file_glob() {
+  local description="$1"
+  local pattern="$2"
+  if ! compgen -G "$pattern" > /dev/null; then
+    echo "Required deployed ${description} is missing: expected ${pattern}" >&2
+    exit 1
+  fi
+}
 
 mkdir -p "${pluginDir}/Linux/x86_64/"
-run_timed "managed DLL deploy" copy_find_batch "$SCRIPTPATH/install/lib/dotnet/" "${pluginDir}" -type f -not -name "*.pdb"
+run_timed "managed DLL deploy" copy_find_batch "$installRoot/lib/dotnet/" "${pluginDir}" -type f -not -name "*.pdb"
 for required_managed in ros2cs_common.dll ros2cs_core.dll; do
   if [ ! -f "${pluginDir}/${required_managed}" ]; then
     echo "Required deployed managed file is missing: ${pluginDir}/${required_managed}" >&2
@@ -93,12 +105,21 @@ for required_managed in ros2cs_common.dll ros2cs_core.dll; do
   fi
 done
 # Standalone/resource outputs are optional; non-standalone builds must still deploy the core plugins.
-if [ -d "$SCRIPTPATH/install/standalone" ]; then
-  run_timed "standalone native deploy" copy_find_batch "$SCRIPTPATH/install/standalone" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \)
+if [ -d "$installRoot/standalone" ]; then
+  run_timed "standalone native deploy" copy_find_batch "$installRoot/standalone" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \)
 fi
-run_timed "native lib deploy" copy_find_batch "$SCRIPTPATH/install/lib/" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -not -name "*_python.so"
-if [ -d "$SCRIPTPATH/install/resources" ]; then
-  run_timed "resource native deploy" copy_find_batch "$SCRIPTPATH/install/resources" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -name "*.so"
+run_timed "native lib deploy" copy_find_batch "$installRoot/lib/" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -not -name "*_python.so"
+if [ -d "$installRoot/resources" ]; then
+  run_timed "resource native deploy" copy_find_batch "$installRoot/resources" "${pluginDir}/Linux/x86_64/" \( -type f -o -type l \) -name "*.so"
+fi
+
+if [ -d "$installRoot/standalone" ] || [ -d "$installRoot/resources" ] || compgen -G "$installRoot/lib/librcl.so*" > /dev/null; then
+  require_file_glob "rcl runtime" "${pluginDir}/Linux/x86_64/librcl.so*"
+  require_file_glob "rmw implementation runtime" "${pluginDir}/Linux/x86_64/librmw_implementation.so*"
+  if ! compgen -G "${pluginDir}/Linux/x86_64/libyaml.so*" > /dev/null && ! compgen -G "${pluginDir}/Linux/x86_64/libyaml-cpp.so*" > /dev/null; then
+    echo "Required deployed YAML runtime is missing: expected libyaml.so* or libyaml-cpp.so* under ${pluginDir}/Linux/x86_64/" >&2
+    exit 1
+  fi
 fi
 
 managed_count=$(find "${pluginDir}" -maxdepth 1 -type f | wc -l)

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,4 @@
+*
+!Dockerfile
+!entrypoint.sh
+!ci_smoke.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 ## Modifications Copyright (c) 2026 Jianbin Liu.
 ##
 ## Modifications by Jianbin Liu:
@@ -11,12 +12,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV R2FU_WORKDIR=/workdir/ros2-for-unity
+ENV NUGET_PACKAGES=/workdir/cache/nuget
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     git \
     patchelf \
+    rsync \
     dotnet-sdk-8.0 \
     ros-${ROS_DISTRO}-test-msgs \
     ros-${ROS_DISTRO}-fastrtps \
@@ -24,8 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-cyclonedds \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     && curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | bash \
-    && apt-get install -y --no-install-recommends python3-vcstool \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends python3-vcstool
 
 COPY entrypoint.sh /entrypoint.sh
 COPY ci_smoke.sh /usr/local/bin/r2fu-ci-smoke
@@ -33,7 +39,7 @@ RUN chmod +x /entrypoint.sh /usr/local/bin/r2fu-ci-smoke
 
 # /workdir must be writable for arbitrary host uid/gid mappings used by run_container.sh.
 # Use a sticky world-writable work root instead of recursively chmodding /home.
-RUN mkdir -p /workdir/ros2-for-unity /workdir/cache /workdir/custom_messages \
-    && chmod 1777 /workdir /workdir/ros2-for-unity /workdir/cache /workdir/custom_messages
+RUN mkdir -p /workdir/ros2-for-unity /workdir/cache/nuget /workdir/custom_messages \
+    && chmod 1777 /workdir /workdir/ros2-for-unity /workdir/cache /workdir/cache/nuget /workdir/custom_messages
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,13 +36,13 @@ RUN curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/scr
     && apt-get install -y --no-install-recommends python3-vcstool \
     && rm -rf /var/lib/apt/lists/*
 
-ADD entrypoint.sh /entrypoint.sh
-ADD ci_smoke.sh /usr/local/bin/r2fu-ci-smoke
+COPY entrypoint.sh /entrypoint.sh
+COPY ci_smoke.sh /usr/local/bin/r2fu-ci-smoke
 RUN chmod +x /entrypoint.sh /usr/local/bin/r2fu-ci-smoke
 
 # /workdir must be writable for arbitrary host uid/gid mappings used by run_container.sh.
 # Use a sticky world-writable work root instead of recursively chmodding /home.
 RUN mkdir -p /workdir/ros2-for-unity /workdir/cache /workdir/custom_messages \
-    && chmod 1777 /workdir /workdir/cache /workdir/custom_messages
+    && chmod 1777 /workdir /workdir/ros2-for-unity /workdir/cache /workdir/custom_messages
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,9 @@
+## Modifications Copyright (c) 2026 Jianbin Liu.
+##
+## Modifications by Jianbin Liu:
+## - Defaulted the container toolchain to Jazzy/.NET 8.
+## - Removed stale apt caches after package installs to keep the image smaller.
+
 ARG ROS2_DISTRO=jazzy
 FROM ros:${ROS2_DISTRO}-ros-base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
 ARG ROS2_DISTRO=jazzy
 FROM ros:${ROS2_DISTRO}-ros-base
 
-RUN apt update && apt install -y ros-${ROS_DISTRO}-test-msgs ros-${ROS_DISTRO}-fastrtps ros-${ROS_DISTRO}-rmw-fastrtps-cpp ros-${ROS_DISTRO}-cyclonedds ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
+RUN apt update && apt install -y ros-${ROS_DISTRO}-test-msgs ros-${ROS_DISTRO}-fastrtps ros-${ROS_DISTRO}-rmw-fastrtps-cpp ros-${ROS_DISTRO}-cyclonedds ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt install -y curl wget git
+RUN apt update && apt install -y curl wget git && rm -rf /var/lib/apt/lists/*
 
 RUN curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | sudo bash
-RUN apt update && apt install -y python3-vcstool
+RUN apt update && apt install -y python3-vcstool && rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt install -y apt-transport-https patchelf dotnet-sdk-8.0
-RUN apt update && apt install -y ffmpeg libsm6 libxext6 libgtk-3-0
+RUN apt update && apt install -y apt-transport-https patchelf dotnet-sdk-8.0 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y ffmpeg libsm6 libxext6 libgtk-3-0 && rm -rf /var/lib/apt/lists/*
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,24 +15,15 @@ ENV R2FU_WORKDIR=/workdir/ros2-for-unity
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    wget \
     git \
-    apt-transport-https \
     patchelf \
     dotnet-sdk-8.0 \
-    ffmpeg \
-    libsm6 \
-    libxext6 \
-    libgtk-3-0 \
     ros-${ROS_DISTRO}-test-msgs \
     ros-${ROS_DISTRO}-fastrtps \
     ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
     ros-${ROS_DISTRO}-cyclonedds \
     ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | bash \
-    && apt-get update \
+    && curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | bash \
     && apt-get install -y --no-install-recommends python3-vcstool \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,25 +3,46 @@
 ## Modifications by Jianbin Liu:
 ## - Defaulted the container toolchain to Jazzy/.NET 8.
 ## - Removed stale apt caches after package installs to keep the image smaller.
+## - Added CI-candidate command helpers and reduced broad filesystem permissions.
 
 ARG ROS2_DISTRO=jazzy
 FROM ros:${ROS2_DISTRO}-ros-base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apt update && apt install -y ros-${ROS_DISTRO}-test-msgs ros-${ROS_DISTRO}-fastrtps ros-${ROS_DISTRO}-rmw-fastrtps-cpp ros-${ROS_DISTRO}-cyclonedds ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=noninteractive
+ENV R2FU_WORKDIR=/workdir/ros2-for-unity
 
-RUN apt update && apt install -y curl wget git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    wget \
+    git \
+    apt-transport-https \
+    patchelf \
+    dotnet-sdk-8.0 \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
+    libgtk-3-0 \
+    ros-${ROS_DISTRO}-test-msgs \
+    ros-${ROS_DISTRO}-fastrtps \
+    ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
+    ros-${ROS_DISTRO}-cyclonedds \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | sudo bash
-RUN apt update && apt install -y python3-vcstool && rm -rf /var/lib/apt/lists/*
-
-RUN apt update && apt install -y apt-transport-https patchelf dotnet-sdk-8.0 && rm -rf /var/lib/apt/lists/*
-RUN apt update && apt install -y ffmpeg libsm6 libxext6 libgtk-3-0 && rm -rf /var/lib/apt/lists/*
+RUN curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | bash \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends python3-vcstool \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+ADD ci_smoke.sh /usr/local/bin/r2fu-ci-smoke
+RUN chmod +x /entrypoint.sh /usr/local/bin/r2fu-ci-smoke
 
-RUN mkdir -p /workdir/ros2-for-unity
-RUN chmod -R 777 /workdir
-RUN chmod -R 777 /home
+# /workdir must be writable for arbitrary host uid/gid mappings used by run_container.sh.
+# Use a sticky world-writable work root instead of recursively chmodding /home.
+RUN mkdir -p /workdir/ros2-for-unity /workdir/cache /workdir/custom_messages \
+    && chmod 1777 /workdir /workdir/cache /workdir/custom_messages
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROS2_DISTRO=humble
+ARG ROS2_DISTRO=jazzy
 FROM ros:${ROS2_DISTRO}-ros-base
 
 RUN apt update && apt install -y ros-${ROS_DISTRO}-test-msgs ros-${ROS_DISTRO}-fastrtps ros-${ROS_DISTRO}-rmw-fastrtps-cpp ros-${ROS_DISTRO}-cyclonedds ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
@@ -8,7 +8,7 @@ RUN apt update && apt install -y curl wget git
 RUN curl -s https://packagecloud.io/install/repositories/dirk-thomas/vcstool/script.deb.sh | sudo bash
 RUN apt update && apt install -y python3-vcstool
 
-RUN apt update && apt install -y apt-transport-https patchelf dotnet-sdk-6.0
+RUN apt update && apt install -y apt-transport-https patchelf dotnet-sdk-8.0
 RUN apt update && apt install -y ffmpeg libsm6 libxext6 libgtk-3-0
 
 ADD entrypoint.sh /entrypoint.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,9 +3,11 @@ Ros2 For Unity Docker
 
 Currently only building asset on Ubuntu is supported. Build windows version is not supported.
 
+Current status: Docker support is legacy guidance in this maintenance line. It has not been revalidated against the current Jazzy/R2FU fixes.
+
 ## Build docker image
 
-1. Source ROS2 (foxy or galactic):
+1. Source ROS2:
 
 ```bash
 . /opt/ros/<ROS_DISTRO>/setup.bash
@@ -19,7 +21,7 @@ Currently only building asset on Ubuntu is supported. Build windows version is n
 
 ## Using docker container
 
-1. Run docker container. Container will fetch `master` version of `ros2-for-unity`:
+1. Run docker container. Container should fetch the maintained branch you intend to build:
 
 ```bash
 ./run_container.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -84,4 +84,6 @@ You can add custom messages by putting them inside `docker/custom_messages` fold
 - `docker/custom_messages` to `/workdir/custom_messages`
 - `docker/cache` to `/workdir/cache`
 
+NuGet packages are cached under `docker/cache/nuget` through `NUGET_PACKAGES=/workdir/cache/nuget`. Remove that directory when you need a cold restore or want to reclaim disk space.
+
 The container runs as the host uid/gid. Generated files should remain writable and removable by the host user.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,9 @@
 Ros2 For Unity Docker
 ===============
 
-Currently only building asset on Ubuntu is supported. Build windows version is not supported.
+Docker is a Linux/Jazzy build and smoke candidate for this fork. It does not build Windows artifacts and it does not run Unity Editor.
 
-Current status: Docker support is legacy guidance in this maintenance line. It has not been revalidated against the current Jazzy/R2FU fixes.
-
-The current Build GREEN / Unity Load GREEN evidence is Windows-native only. Docker output should not be treated as validated for the current Jazzy maintenance line until a fresh Docker build record is added.
+Current status: Docker must pass the `r2fu-ci` command before it is treated as CI-candidate GREEN. Until then, Docker output is diagnostic evidence only.
 
 ## Build docker image
 
@@ -21,6 +19,12 @@ The current Build GREEN / Unity Load GREEN evidence is Windows-native only. Dock
 ./build_image.sh
 ```
 
+Optional image name override:
+
+```bash
+R2FU_DOCKER_IMAGE=ros2-for-unity:jazzy-ci-candidate ./build_image.sh
+```
+
 ## Using docker container
 
 1. Run docker container. Container should fetch the maintained branch you intend to build:
@@ -29,12 +33,43 @@ The current Build GREEN / Unity Load GREEN evidence is Windows-native only. Dock
 ./run_container.sh
 ```
 
+With no arguments, `run_container.sh` executes `r2fu-shell`, which prepares the workspace and then opens a shell.
+
 2. Build asset. `./run_container.sh` script mounts `install` host directory inside docker, so you can find install results on host machine:
 
 ```bash
-./build.sh --with-tests
+./run_container.sh r2fu-build
 ```
+
+3. Run the CI-candidate command:
+
+```bash
+R2FU_DOCKER_IMAGE=ros2-for-unity:jazzy-ci-candidate \
+R2FU_REF=main \
+./run_container.sh r2fu-ci
+```
+
+`R2FU_REF` is checked out from `R2FU_REPO` inside the container. Use a branch or tag that already exists in that remote repository; local-only branches are not visible to the container.
+
+`r2fu-ci` performs:
+
+- repository checkout/import;
+- standalone build with tests enabled;
+- ros2cs test execution;
+- artifact closure smoke through `r2fu-ci-smoke`.
+
+The smoke checks required managed DLLs, required Linux native libraries, `ldd` closure for `librcl`, and basic ROS 2 CLI context availability.
 
 ## Adding custom messages
 
 You can add custom messages by putting them inside `docker/custom_messages` folder or just simply `git clone` them inside docker containers `/workdir/ros2-for-unity/src/ros2cs/src/custom_messages`
+
+## Mounts and cache
+
+`run_container.sh` mounts:
+
+- `../install` to `/workdir/ros2-for-unity/install`
+- `docker/custom_messages` to `/workdir/custom_messages`
+- `docker/cache` to `/workdir/cache`
+
+The container runs as the host uid/gid. Generated files should remain writable and removable by the host user.

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,6 +5,8 @@ Currently only building asset on Ubuntu is supported. Build windows version is n
 
 Current status: Docker support is legacy guidance in this maintenance line. It has not been revalidated against the current Jazzy/R2FU fixes.
 
+The current Build GREEN / Unity Load GREEN evidence is Windows-native only. Docker output should not be treated as validated for the current Jazzy maintenance line until a fresh Docker build record is added.
+
 ## Build docker image
 
 1. Source ROS2:

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,6 +5,18 @@ Docker is a Linux/Jazzy build and smoke candidate for this fork. It does not bui
 
 Current status: Docker must pass the `r2fu-ci` command before it is treated as CI-candidate GREEN. Until then, Docker output is diagnostic evidence only.
 
+## Fastest CI-candidate path
+
+From the `docker/` directory:
+
+```bash
+. /opt/ros/jazzy/setup.bash
+./build_image.sh
+./run_container.sh r2fu-ci
+```
+
+The final command emits `R2FU_DOCKER_CI_SMOKE_PASS` when the build, tests, and smoke checks pass.
+
 ## Build docker image
 
 1. Source ROS2:

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -14,4 +14,6 @@ fi
 
 IMAGE_NAME=${R2FU_DOCKER_IMAGE:-ros2-for-unity}
 
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
 docker build . --build-arg ROS2_DISTRO="$ROS_DISTRO" --tag "$IMAGE_NAME"

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Passed the sourced ROS_DISTRO into the Docker build as an explicit build argument.
+
 set -euo pipefail
 
 if [ -z "${ROS_DISTRO:-}" ]; then

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 
-if [ -z "$ROS_DISTRO" ]; then
+if [ -z "${ROS_DISTRO:-}" ]; then
     echo "Source your ros2 distro first."
     exit 1
 fi
 
-docker build . --build-arg ROS2_DISTRO=$ROS_DISTRO --tag ros2-for-unity
+docker build . --build-arg ROS2_DISTRO="$ROS_DISTRO" --tag ros2-for-unity

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -3,6 +3,7 @@
 #
 # Modifications by Jianbin Liu:
 # - Passed the sourced ROS_DISTRO into the Docker build as an explicit build argument.
+# - Added image-name override for CI-candidate builds.
 
 set -euo pipefail
 
@@ -11,4 +12,6 @@ if [ -z "${ROS_DISTRO:-}" ]; then
     exit 1
 fi
 
-docker build . --build-arg ROS2_DISTRO="$ROS_DISTRO" --tag ros2-for-unity
+IMAGE_NAME=${R2FU_DOCKER_IMAGE:-ros2-for-unity}
+
+docker build . --build-arg ROS2_DISTRO="$ROS_DISTRO" --tag "$IMAGE_NAME"

--- a/docker/ci_smoke.sh
+++ b/docker/ci_smoke.sh
@@ -10,6 +10,8 @@ workspace="${1:-${R2FU_WORKDIR:-/workdir/ros2-for-unity}}"
 asset_dir="$workspace/install/asset/Ros2ForUnity"
 plugin_dir="$asset_dir/Plugins"
 native_dir="$plugin_dir/Linux/x86_64"
+ldd_log=$(mktemp "${TMPDIR:-/tmp}/r2fu-ci-smoke-ldd.XXXXXX")
+topic_log=$(mktemp "${TMPDIR:-/tmp}/r2fu-ci-smoke-topic-list.XXXXXX")
 
 source "/opt/ros/$ROS_DISTRO/setup.bash"
 
@@ -41,16 +43,17 @@ require_glob "$native_dir/librmw_implementation.so*" >/dev/null
 require_glob "$native_dir/libyaml*.so*" >/dev/null
 
 echo "Checking native dependency closure with ldd: $rcl_lib"
-ldd "$rcl_lib" | tee /tmp/r2fu-ci-smoke-ldd.txt
-if grep -q "not found" /tmp/r2fu-ci-smoke-ldd.txt; then
+ldd "$rcl_lib" | tee "$ldd_log"
+if grep -q "not found" "$ldd_log"; then
   echo "Native dependency closure has unresolved libraries." >&2
+  echo "ldd log: $ldd_log" >&2
   exit 1
 fi
 
 echo "Checking ROS 2 CLI context availability."
-timeout 30s ros2 topic list >/tmp/r2fu-ci-smoke-topic-list.txt
+timeout 30s ros2 topic list >"$topic_log"
 
 managed_count=$(find "$plugin_dir" -maxdepth 1 -type f | wc -l)
 native_count=$(find "$native_dir" -maxdepth 1 -type f | wc -l)
 
-echo "R2FU_DOCKER_CI_SMOKE_PASS managed=$managed_count native=$native_count rmw=${RMW_IMPLEMENTATION:-unset}"
+echo "R2FU_DOCKER_CI_SMOKE_PASS managed=$managed_count native=$native_count rmw=${RMW_IMPLEMENTATION:-unset} ldd_log=$ldd_log topic_log=$topic_log"

--- a/docker/ci_smoke.sh
+++ b/docker/ci_smoke.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added a Docker CI-candidate smoke check for R2FU Linux artifact closure.
+
+set -euo pipefail
+
+workspace="${1:-${R2FU_WORKDIR:-/workdir/ros2-for-unity}}"
+asset_dir="$workspace/install/asset/Ros2ForUnity"
+plugin_dir="$asset_dir/Plugins"
+native_dir="$plugin_dir/Linux/x86_64"
+
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+
+require_file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "Required file missing: $path" >&2
+    exit 1
+  fi
+}
+
+require_glob() {
+  local pattern="$1"
+  shopt -s nullglob
+  local matches=( $pattern )
+  shopt -u nullglob
+  if [ "${#matches[@]}" -eq 0 ]; then
+    echo "Required file pattern missing: $pattern" >&2
+    exit 1
+  fi
+  echo "${matches[0]}"
+}
+
+require_file "$plugin_dir/ros2cs_common.dll"
+require_file "$plugin_dir/ros2cs_core.dll"
+
+rcl_lib=$(require_glob "$native_dir/librcl.so*")
+require_glob "$native_dir/librmw_implementation.so*" >/dev/null
+require_glob "$native_dir/libyaml*.so*" >/dev/null
+
+echo "Checking native dependency closure with ldd: $rcl_lib"
+ldd "$rcl_lib" | tee /tmp/r2fu-ci-smoke-ldd.txt
+if grep -q "not found" /tmp/r2fu-ci-smoke-ldd.txt; then
+  echo "Native dependency closure has unresolved libraries." >&2
+  exit 1
+fi
+
+echo "Checking ROS 2 CLI context availability."
+timeout 30s ros2 topic list >/tmp/r2fu-ci-smoke-topic-list.txt
+
+managed_count=$(find "$plugin_dir" -maxdepth 1 -type f | wc -l)
+native_count=$(find "$native_dir" -maxdepth 1 -type f | wc -l)
+
+echo "R2FU_DOCKER_CI_SMOKE_PASS managed=$managed_count native=$native_count rmw=${RMW_IMPLEMENTATION:-unset}"

--- a/docker/ci_smoke.sh
+++ b/docker/ci_smoke.sh
@@ -12,6 +12,15 @@ plugin_dir="$asset_dir/Plugins"
 native_dir="$plugin_dir/Linux/x86_64"
 ldd_log=$(mktemp "${TMPDIR:-/tmp}/r2fu-ci-smoke-ldd.XXXXXX")
 topic_log=$(mktemp "${TMPDIR:-/tmp}/r2fu-ci-smoke-topic-list.XXXXXX")
+cleanup() {
+  local status=$?
+  if [ "$status" -eq 0 ]; then
+    rm -f "$ldd_log" "$topic_log"
+  else
+    echo "Keeping smoke diagnostic logs: $ldd_log $topic_log" >&2
+  fi
+}
+trap cleanup EXIT
 
 source "/opt/ros/$ROS_DISTRO/setup.bash"
 
@@ -38,12 +47,17 @@ require_glob() {
 require_file "$plugin_dir/ros2cs_common.dll"
 require_file "$plugin_dir/ros2cs_core.dll"
 
-rcl_lib=$(require_glob "$native_dir/librcl.so*")
+require_glob "$native_dir/librcl.so*" >/dev/null
 require_glob "$native_dir/librmw_implementation.so*" >/dev/null
 require_glob "$native_dir/libyaml*.so*" >/dev/null
 
-echo "Checking native dependency closure with ldd: $rcl_lib"
-ldd "$rcl_lib" | tee "$ldd_log"
+echo "Checking native dependency closure with ldd."
+find "$native_dir" -maxdepth 1 -type f -name "*.so*" -print0 |
+  sort -z |
+  while IFS= read -r -d '' native_lib; do
+    echo "==> $native_lib"
+    ldd "$native_lib"
+  done | tee "$ldd_log"
 if grep -q "not found" "$ldd_log"; then
   echo "Native dependency closure has unresolved libraries." >&2
   echo "ldd log: $ldd_log" >&2

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,7 @@
 # Modifications by Jianbin Liu:
 # - Added R2FU_REPO and R2FU_REF overrides for fork-aware container builds.
 # - Preserved the custom messages junction expected by the ros2cs workspace layout.
+# - Added explicit CI-candidate commands: r2fu-shell, r2fu-build, r2fu-smoke, and r2fu-ci.
 
 set -euo pipefail
 
@@ -12,37 +13,106 @@ source "/opt/ros/$ROS_DISTRO/setup.bash"
 # These overrides let CI build a fork/ref without baking repository identity into the image.
 R2FU_REPO=${R2FU_REPO:-https://github.com/JianbinLiu-CFLab/ros2-for-unity.git}
 R2FU_REF=${R2FU_REF:-main}
+R2FU_WORKDIR=${R2FU_WORKDIR:-/workdir/ros2-for-unity}
+R2FU_CLONE_TMP=${R2FU_CLONE_TMP:-/workdir/.ros2-for-unity}
+R2FU_CUSTOM_MESSAGES_DIR=${R2FU_CUSTOM_MESSAGES_DIR:-/workdir/custom_messages}
 
-echo "######################################################################"
-echo ""
-echo "Cloning '$R2FU_REF' from '$R2FU_REPO'"
-echo ""
-echo "######################################################################"
-echo ""
-
-git clone --branch "$R2FU_REF" "$R2FU_REPO" /workdir/.ros2-for-unity
-
-shopt -s dotglob
-mkdir -p /workdir/ros2-for-unity
-mv /workdir/.ros2-for-unity/* /workdir/ros2-for-unity
-cd /workdir/ros2-for-unity/ && ./pull_repositories.sh
-mkdir -p "/home/$(whoami)"
-git config --global --add safe.directory /workdir/ros2-for-unity
-shopt -u dotglob
-
-# Keep the historical ros2cs custom message path when the host mounted that directory.
-if [ -d /workdir/custom_messages ]; then
-  ln -sfn /workdir/custom_messages /workdir/ros2-for-unity/src/ros2cs/src/custom_messages
-else
-  echo "No /workdir/custom_messages mount found; skipping custom message symlink."
+if [ -z "${HOME:-}" ] || [ ! -w "${HOME:-/}" ]; then
+  export HOME=/tmp/r2fu-home
 fi
+mkdir -p "$HOME"
+
+prepare_workspace() {
+  echo "######################################################################"
+  echo ""
+  echo "Preparing '$R2FU_REF' from '$R2FU_REPO'"
+  echo ""
+  echo "######################################################################"
+  echo ""
+
+  rm -rf "$R2FU_CLONE_TMP"
+  git clone "$R2FU_REPO" "$R2FU_CLONE_TMP"
+  cd "$R2FU_CLONE_TMP"
+  git checkout "$R2FU_REF"
+
+  mkdir -p "$R2FU_WORKDIR"
+  find "$R2FU_WORKDIR" -mindepth 1 -maxdepth 1 ! -name install -exec rm -rf {} +
+
+  shopt -s dotglob
+  mv "$R2FU_CLONE_TMP"/* "$R2FU_WORKDIR"
+  shopt -u dotglob
+  rm -rf "$R2FU_CLONE_TMP"
+
+  cd "$R2FU_WORKDIR"
+  git config --global --add safe.directory "$R2FU_WORKDIR"
+
+  ./pull_repositories.sh
+
+  # Keep the historical ros2cs custom message path when the host mounted that directory.
+  if [ -d "$R2FU_CUSTOM_MESSAGES_DIR" ]; then
+    ln -sfn "$R2FU_CUSTOM_MESSAGES_DIR" "$R2FU_WORKDIR/src/ros2cs/src/custom_messages"
+  else
+    echo "No custom messages directory found at '$R2FU_CUSTOM_MESSAGES_DIR'; skipping custom message symlink."
+  fi
+}
+
+r2fu_build() {
+  prepare_workspace
+  cd "$R2FU_WORKDIR"
+  ./build.sh --standalone --with-tests "$@"
+}
+
+r2fu_test() {
+  cd "$R2FU_WORKDIR/src/ros2cs"
+  ./test.sh
+}
+
+r2fu_smoke() {
+  /usr/local/bin/r2fu-ci-smoke "$R2FU_WORKDIR"
+}
+
+r2fu_shell() {
+  prepare_workspace
+  cd "$R2FU_WORKDIR"
+  exec bash
+}
+
+case "${1:-}" in
+  r2fu-shell)
+    shift
+    r2fu_shell "$@"
+    ;;
+  r2fu-build)
+    shift
+    r2fu_build "$@"
+    exit 0
+    ;;
+  r2fu-smoke)
+    shift
+    r2fu_smoke "$@"
+    exit 0
+    ;;
+  r2fu-ci)
+    shift
+    r2fu_build "$@"
+    r2fu_test
+    r2fu_smoke
+    exit 0
+    ;;
+esac
 
 echo ""
 echo "######################################################################"
 echo ""
 echo "Welcome to 'ros2-for-unity' docker container. Your ROS2 distro is $ROS_DISTRO."
 echo ""
-echo "Type './build.sh' to build 'ros2-for-unity'. You will find installed libs on your host machine inside 'install' directory"
+echo "CI commands:"
+echo "  r2fu-shell"
+echo "  r2fu-build [extra build.sh args]"
+echo "  r2fu-smoke"
+echo "  r2fu-ci [extra build.sh args]"
+echo ""
+echo "For an interactive prepared workspace, run: r2fu-shell"
 echo ""
 echo "######################################################################"
 echo ""

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,11 @@ mkdir -p "/home/$(whoami)"
 git config --global --add safe.directory /workdir/ros2-for-unity
 shopt -u dotglob
 
-ln -sfn /workdir/custom_messages /workdir/ros2-for-unity/src/ros2cs/src/custom_messages
+if [ -d /workdir/custom_messages ]; then
+  ln -sfn /workdir/custom_messages /workdir/ros2-for-unity/src/ros2cs/src/custom_messages
+else
+  echo "No /workdir/custom_messages mount found; skipping custom message symlink."
+fi
 
 echo ""
 echo "######################################################################"
@@ -34,5 +38,9 @@ echo "Type './build.sh' to build 'ros2-for-unity'. You will find installed libs 
 echo ""
 echo "######################################################################"
 echo ""
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
 
 exec bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
+set -euo pipefail
 
 source "/opt/ros/$ROS_DISTRO/setup.bash"
 
+R2FU_REPO=${R2FU_REPO:-https://github.com/JianbinLiu-CFLab/ros2-for-unity.git}
+R2FU_REF=${R2FU_REF:-main}
+
 echo "######################################################################"
 echo ""
-echo "Cloning recent version of 'ros2-for-unity'"
+echo "Cloning '$R2FU_REF' from '$R2FU_REPO'"
 echo ""
 echo "######################################################################"
 echo ""
 
-git clone https://github.com/RobotecAI/ros2-for-unity.git /workdir/.ros2-for-unity
+git clone --branch "$R2FU_REF" "$R2FU_REPO" /workdir/.ros2-for-unity
 
 shopt -s dotglob
 mkdir -p /workdir/ros2-for-unity
 mv /workdir/.ros2-for-unity/* /workdir/ros2-for-unity
 cd /workdir/ros2-for-unity/ && ./pull_repositories.sh
-mkdir -p /home/$(whoami)
+mkdir -p "/home/$(whoami)"
 git config --global --add safe.directory /workdir/ros2-for-unity
 shopt -u dotglob
 
-ln -s /workdir/custom_messages /workdir/ros2-for-unity/src/ros2cs/src/custom_messages
+ln -sfn /workdir/custom_messages /workdir/ros2-for-unity/src/ros2cs/src/custom_messages
 
 echo ""
 echo "######################################################################"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Added R2FU_REPO and R2FU_REF overrides for fork-aware container builds.
+# - Preserved the custom messages junction expected by the ros2cs workspace layout.
+
 set -euo pipefail
 
 source "/opt/ros/$ROS_DISTRO/setup.bash"
 
+# These overrides let CI build a fork/ref without baking repository identity into the image.
 R2FU_REPO=${R2FU_REPO:-https://github.com/JianbinLiu-CFLab/ros2-for-unity.git}
 R2FU_REF=${R2FU_REF:-main}
 
@@ -23,6 +30,7 @@ mkdir -p "/home/$(whoami)"
 git config --global --add safe.directory /workdir/ros2-for-unity
 shopt -u dotglob
 
+# Keep the historical ros2cs custom message path when the host mounted that directory.
 if [ -d /workdir/custom_messages ]; then
   ln -sfn /workdir/custom_messages /workdir/ros2-for-unity/src/ros2cs/src/custom_messages
 else

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -99,6 +99,11 @@ case "${1:-}" in
     r2fu_smoke
     exit 0
     ;;
+  r2fu-*)
+    echo "Unknown R2FU container command: $1" >&2
+    echo "Known commands: r2fu-shell, r2fu-build, r2fu-smoke, r2fu-ci" >&2
+    exit 1
+    ;;
 esac
 
 echo ""

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,8 @@ if [ -z "${HOME:-}" ] || [ ! -w "${HOME:-/}" ]; then
   export HOME=/tmp/r2fu-home
 fi
 mkdir -p "$HOME"
+export NUGET_PACKAGES=${NUGET_PACKAGES:-/workdir/cache/nuget}
+mkdir -p "$NUGET_PACKAGES"
 
 prepare_workspace() {
   echo "######################################################################"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -31,9 +31,14 @@ prepare_workspace() {
   echo ""
 
   rm -rf "$R2FU_CLONE_TMP"
-  git clone "$R2FU_REPO" "$R2FU_CLONE_TMP"
-  cd "$R2FU_CLONE_TMP"
-  git checkout "$R2FU_REF"
+  if [[ "$R2FU_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    git clone "$R2FU_REPO" "$R2FU_CLONE_TMP"
+    cd "$R2FU_CLONE_TMP"
+    git checkout "$R2FU_REF"
+  else
+    git clone --depth 1 --branch "$R2FU_REF" "$R2FU_REPO" "$R2FU_CLONE_TMP"
+    cd "$R2FU_CLONE_TMP"
+  fi
 
   mkdir -p "$R2FU_WORKDIR"
   find "$R2FU_WORKDIR" -mindepth 1 -maxdepth 1 ! -name install -exec rm -rf {} +

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-SCRIPT=$(readlink -f $0)
-SCRIPTPATH=`dirname $SCRIPT`
+set -euo pipefail
 
-mkdir -p $SCRIPTPATH/../install
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+mkdir -p "$SCRIPTPATH/../install"
 docker run \
 --rm \
 -it \
 --name ros2-for-unity \
---user $(id -u):$(id -g) \
+--user "$(id -u):$(id -g)" \
 -v /etc/passwd:/etc/passwd:ro \
 -v /etc/group:/etc/group:ro \
--v /etc/shadow:/etc/shadow:ro \
--v $(pwd)/../install:/workdir/ros2-for-unity/install:rw \
--v $(pwd)/custom_messages:/workdir/custom_messages \
+-v "$SCRIPTPATH/../install:/workdir/ros2-for-unity/install:rw" \
+-v "$SCRIPTPATH/custom_messages:/workdir/custom_messages" \
 ros2-for-unity \
 bash

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Removed /etc/shadow mounting and kept only passwd/group read-only identity mappings.
+# - Mounted install and custom_messages directories explicitly for local artifact builds.
+
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -36,6 +36,7 @@ docker_args=(
   --user "$(id -u):$(id -g)"
   -e "R2FU_REPO=$R2FU_REPO"
   -e "R2FU_REF=$R2FU_REF"
+  -e "NUGET_PACKAGES=/workdir/cache/nuget"
   -v /etc/passwd:/etc/passwd:ro
   -v /etc/group:/etc/group:ro
   -v "$SCRIPTPATH/../install:/workdir/ros2-for-unity/install:rw"

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -4,21 +4,43 @@
 # Modifications by Jianbin Liu:
 # - Removed /etc/shadow mounting and kept only passwd/group read-only identity mappings.
 # - Mounted install and custom_messages directories explicitly for local artifact builds.
+# - Added command passthrough and cache/output mount policy for CI-candidate runs.
+# - Avoided forcing TTY allocation when running in non-interactive CI shells.
 
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
+IMAGE_NAME=${R2FU_DOCKER_IMAGE:-ros2-for-unity}
+CONTAINER_NAME=${R2FU_DOCKER_CONTAINER_NAME:-ros2-for-unity}
+R2FU_REPO=${R2FU_REPO:-https://github.com/JianbinLiu-CFLab/ros2-for-unity.git}
+R2FU_REF=${R2FU_REF:-main}
 
 mkdir -p "$SCRIPTPATH/../install"
-docker run \
---rm \
--it \
---name ros2-for-unity \
---user "$(id -u):$(id -g)" \
--v /etc/passwd:/etc/passwd:ro \
--v /etc/group:/etc/group:ro \
--v "$SCRIPTPATH/../install:/workdir/ros2-for-unity/install:rw" \
--v "$SCRIPTPATH/custom_messages:/workdir/custom_messages" \
-ros2-for-unity \
-bash
+mkdir -p "$SCRIPTPATH/cache"
+mkdir -p "$SCRIPTPATH/custom_messages"
+
+if [ "$#" -eq 0 ]; then
+  set -- r2fu-shell
+fi
+
+DOCKER_TTY_ARGS=()
+if [ -t 0 ] && [ "${R2FU_DOCKER_TTY:-auto}" != "false" ]; then
+  DOCKER_TTY_ARGS=(-it)
+fi
+
+docker_args=(
+  --rm
+  "${DOCKER_TTY_ARGS[@]}"
+  --name "$CONTAINER_NAME"
+  --user "$(id -u):$(id -g)"
+  -e "R2FU_REPO=$R2FU_REPO"
+  -e "R2FU_REF=$R2FU_REF"
+  -v /etc/passwd:/etc/passwd:ro
+  -v /etc/group:/etc/group:ro
+  -v "$SCRIPTPATH/../install:/workdir/ros2-for-unity/install:rw"
+  -v "$SCRIPTPATH/custom_messages:/workdir/custom_messages"
+  -v "$SCRIPTPATH/cache:/workdir/cache:rw"
+)
+
+docker run "${docker_args[@]}" "$IMAGE_NAME" "$@"

--- a/pull_repositories.ps1
+++ b/pull_repositories.ps1
@@ -18,6 +18,11 @@ if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
 $ros2cs_repos = Join-Path -Path $scriptPath -ChildPath "ros2cs.repos"
 $custom_repos = Join-Path -Path $scriptPath -ChildPath "ros2_for_unity_custom_messages.repos"
 
+function Test-HasVcsRepositoryEntries {
+    param([Parameter(Mandatory=$true)][string]$Path)
+    return [bool](Select-String -Path $Path -Pattern '^\s+type:' -Quiet)
+}
+
 # Anchor vcs imports at the repository root so callers can run this script from any CWD.
 Push-Location $scriptPath
 try {
@@ -29,8 +34,12 @@ try {
     Write-Host ""
     Write-Host "========================================="
     Write-Host "Pulling custom repositories:"
-    vcs import --input $custom_repos
-    if ($LASTEXITCODE -ne 0) { throw "vcs import custom messages failed with exit code $LASTEXITCODE" }
+    if (Test-HasVcsRepositoryEntries -Path $custom_repos) {
+        vcs import --input $custom_repos
+        if ($LASTEXITCODE -ne 0) { throw "vcs import custom messages failed with exit code $LASTEXITCODE" }
+    } else {
+        Write-Host "No custom repositories defined; skipping vcs import."
+    }
 
     Write-Host ""
     Write-Host "========================================="

--- a/pull_repositories.ps1
+++ b/pull_repositories.ps1
@@ -1,9 +1,12 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
 if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
 {
-    Write-Host "Can't detect ROS2 version. Source your ros2 distro first. Foxy and Galactic are supported." -ForegroundColor Red
-    exit
+    Write-Host "Can't detect ROS2 version. Source your ROS 2 distro first. Humble and Jazzy are the maintained targets; Foxy/Galactic are historical." -ForegroundColor Red
+    exit 1
 }
 
 $ros2cs_repos = Join-Path -Path $scriptPath -ChildPath "\ros2cs.repos"
@@ -12,13 +15,16 @@ $custom_repos = Join-Path -Path $scriptPath -ChildPath "\ros2_for_unity_custom_m
 Write-Host "========================================="
 Write-Host "* Pulling ros2cs repository:"
 vcs import --input $ros2cs_repos
+if ($LASTEXITCODE -ne 0) { throw "vcs import ros2cs.repos failed with exit code $LASTEXITCODE" }
 
 Write-Host ""
 Write-Host "========================================="
 Write-Host "Pulling custom repositories:"
 vcs import --input $custom_repos
+if ($LASTEXITCODE -ne 0) { throw "vcs import custom messages failed with exit code $LASTEXITCODE" }
 
 Write-Host ""
 Write-Host "========================================="
 Write-Host "Pulling ros2cs dependencies:"
 & "$scriptPath/src/ros2cs/get_repos.ps1"
+if ($LASTEXITCODE -ne 0) { throw "ros2cs get_repos.ps1 failed with exit code $LASTEXITCODE" }

--- a/pull_repositories.ps1
+++ b/pull_repositories.ps1
@@ -7,7 +7,7 @@ Set-StrictMode -Version Latest
 # - Updated supported ROS distribution messaging for Humble/Jazzy maintenance.
 # - Made repository imports run from the repository root instead of the caller's current directory.
 
-$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
 if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
 {

--- a/pull_repositories.ps1
+++ b/pull_repositories.ps1
@@ -1,6 +1,12 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Updated supported ROS distribution messaging for Humble/Jazzy maintenance.
+# - Made repository imports run from the repository root instead of the caller's current directory.
+
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 
 if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
@@ -12,6 +18,7 @@ if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
 $ros2cs_repos = Join-Path -Path $scriptPath -ChildPath "ros2cs.repos"
 $custom_repos = Join-Path -Path $scriptPath -ChildPath "ros2_for_unity_custom_messages.repos"
 
+# Anchor vcs imports at the repository root so callers can run this script from any CWD.
 Push-Location $scriptPath
 try {
     Write-Host "========================================="

--- a/pull_repositories.ps1
+++ b/pull_repositories.ps1
@@ -9,22 +9,27 @@ if (([string]::IsNullOrEmpty($Env:ROS_DISTRO)))
     exit 1
 }
 
-$ros2cs_repos = Join-Path -Path $scriptPath -ChildPath "\ros2cs.repos"
-$custom_repos = Join-Path -Path $scriptPath -ChildPath "\ros2_for_unity_custom_messages.repos"
+$ros2cs_repos = Join-Path -Path $scriptPath -ChildPath "ros2cs.repos"
+$custom_repos = Join-Path -Path $scriptPath -ChildPath "ros2_for_unity_custom_messages.repos"
 
-Write-Host "========================================="
-Write-Host "* Pulling ros2cs repository:"
-vcs import --input $ros2cs_repos
-if ($LASTEXITCODE -ne 0) { throw "vcs import ros2cs.repos failed with exit code $LASTEXITCODE" }
+Push-Location $scriptPath
+try {
+    Write-Host "========================================="
+    Write-Host "* Pulling ros2cs repository:"
+    vcs import --input $ros2cs_repos
+    if ($LASTEXITCODE -ne 0) { throw "vcs import ros2cs.repos failed with exit code $LASTEXITCODE" }
 
-Write-Host ""
-Write-Host "========================================="
-Write-Host "Pulling custom repositories:"
-vcs import --input $custom_repos
-if ($LASTEXITCODE -ne 0) { throw "vcs import custom messages failed with exit code $LASTEXITCODE" }
+    Write-Host ""
+    Write-Host "========================================="
+    Write-Host "Pulling custom repositories:"
+    vcs import --input $custom_repos
+    if ($LASTEXITCODE -ne 0) { throw "vcs import custom messages failed with exit code $LASTEXITCODE" }
 
-Write-Host ""
-Write-Host "========================================="
-Write-Host "Pulling ros2cs dependencies:"
-& "$scriptPath/src/ros2cs/get_repos.ps1"
-if ($LASTEXITCODE -ne 0) { throw "ros2cs get_repos.ps1 failed with exit code $LASTEXITCODE" }
+    Write-Host ""
+    Write-Host "========================================="
+    Write-Host "Pulling ros2cs dependencies:"
+    & "$scriptPath/src/ros2cs/get_repos.ps1"
+    if ($LASTEXITCODE -ne 0) { throw "ros2cs get_repos.ps1 failed with exit code $LASTEXITCODE" }
+} finally {
+    Pop-Location
+}

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -20,13 +20,13 @@ echo "========================================="
 echo "* Pulling ros2cs repository:"
 # Anchor vcs imports at the repository root so callers can run this script from any CWD.
 cd "$SCRIPTPATH"
-vcs import --input "$SCRIPTPATH/ros2cs.repos"
+vcs import --shallow --input "$SCRIPTPATH/ros2cs.repos"
 
 echo ""
 echo "========================================="
 echo "Pulling custom repositories:"
 if grep -qE '^[[:space:]]+type:' "$custom_repos"; then
-    vcs import --input "$custom_repos"
+    vcs import --shallow --input "$custom_repos"
 else
     echo "No custom repositories defined; skipping vcs import."
 fi

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
+set -euo pipefail
 
-SCRIPT=$(readlink -f $0)
-SCRIPTPATH=`dirname $SCRIPT`
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
 
-if [ -z "${ROS_DISTRO}" ]; then
-    echo "Can't detect ROS2 version. Source your ros2 distro first. Foxy, Galactic, Humble, Jazzy are supported"
+if [ -z "${ROS_DISTRO:-}" ]; then
+    echo "Can't detect ROS2 version. Source your ROS 2 distro first. Humble and Jazzy are the maintained targets; Foxy/Galactic are historical."
     exit 1
 fi
 
 echo "========================================="
 echo "* Pulling ros2cs repository:"
-vcs import < "ros2cs.repos"
+vcs import < "$SCRIPTPATH/ros2cs.repos"
 
 echo ""
 echo "========================================="
 echo "Pulling custom repositories:"
-vcs import < "ros2_for_unity_custom_messages.repos"
+vcs import < "$SCRIPTPATH/ros2_for_unity_custom_messages.repos"
 
 echo ""
 echo "========================================="
 echo "Pulling ros2cs dependencies:"
 cd "$SCRIPTPATH/src/ros2cs"
 ./get_repos.sh
-cd -
+cd - > /dev/null

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -11,6 +11,7 @@ fi
 
 echo "========================================="
 echo "* Pulling ros2cs repository:"
+cd "$SCRIPTPATH"
 vcs import < "$SCRIPTPATH/ros2cs.repos"
 
 echo ""
@@ -23,4 +24,3 @@ echo "========================================="
 echo "Pulling ros2cs dependencies:"
 cd "$SCRIPTPATH/src/ros2cs"
 ./get_repos.sh
-cd - > /dev/null

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Updated supported ROS distribution messaging for Humble/Jazzy maintenance.
+# - Made repository imports run from the repository root instead of the caller's current directory.
+
 set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
@@ -11,6 +17,7 @@ fi
 
 echo "========================================="
 echo "* Pulling ros2cs repository:"
+# Anchor vcs imports at the repository root so callers can run this script from any CWD.
 cd "$SCRIPTPATH"
 vcs import < "$SCRIPTPATH/ros2cs.repos"
 

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -4,7 +4,7 @@ SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 
 if [ -z "${ROS_DISTRO}" ]; then
-    echo "Can't detect ROS2 version. Source your ros2 distro first. Foxy and Galactic are supported"
+    echo "Can't detect ROS2 version. Source your ros2 distro first. Foxy, Galactic, Humble, Jazzy are supported"
     exit 1
 fi
 

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -19,12 +19,12 @@ echo "========================================="
 echo "* Pulling ros2cs repository:"
 # Anchor vcs imports at the repository root so callers can run this script from any CWD.
 cd "$SCRIPTPATH"
-vcs import < "$SCRIPTPATH/ros2cs.repos"
+vcs import --input "$SCRIPTPATH/ros2cs.repos"
 
 echo ""
 echo "========================================="
 echo "Pulling custom repositories:"
-vcs import < "$SCRIPTPATH/ros2_for_unity_custom_messages.repos"
+vcs import --input "$SCRIPTPATH/ros2_for_unity_custom_messages.repos"
 
 echo ""
 echo "========================================="

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
+custom_repos="$SCRIPTPATH/ros2_for_unity_custom_messages.repos"
 
 if [ -z "${ROS_DISTRO:-}" ]; then
     echo "Can't detect ROS2 version. Source your ROS 2 distro first. Humble and Jazzy are the maintained targets; Foxy/Galactic are historical."
@@ -24,7 +25,11 @@ vcs import --input "$SCRIPTPATH/ros2cs.repos"
 echo ""
 echo "========================================="
 echo "Pulling custom repositories:"
-vcs import --input "$SCRIPTPATH/ros2_for_unity_custom_messages.repos"
+if grep -qE '^[[:space:]]+type:' "$custom_repos"; then
+    vcs import --input "$custom_repos"
+else
+    echo "No custom repositories defined; skipping vcs import."
+fi
 
 echo ""
 echo "========================================="

--- a/pull_repositories.sh
+++ b/pull_repositories.sh
@@ -29,5 +29,4 @@ vcs import --input "$SCRIPTPATH/ros2_for_unity_custom_messages.repos"
 echo ""
 echo "========================================="
 echo "Pulling ros2cs dependencies:"
-cd "$SCRIPTPATH/src/ros2cs"
-./get_repos.sh
+(cd "$SCRIPTPATH/src/ros2cs" && ./get_repos.sh)

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -4,9 +4,10 @@
 # - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
 # - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
 # - Pinned the dependency to a verified ros2cs mainline commit for reproducible public builds.
+# - Updated the pin to include the rosidl_python path-length root-cause fix.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 5f6556628328e1a420577315842f9ae81448d9b0
+    version: 01a44c8f07883c7aa2bbf9ed18b59b1993ef862b

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -3,10 +3,10 @@
 # Modifications by Jianbin Liu:
 # - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
 # - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
-# - Pinned the dependency to a preview tag for reproducible public builds.
+# - Pinned the dependency to a verified ros2cs mainline commit for reproducible public builds.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: v0.4.0-jazzy-preview.1
+    version: 636f08a8a0c12c0808aa6899208de72e1185865b

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -2,4 +2,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/RobotecAI/ros2cs.git
-    version: 1.3.0
+    version: feature/jazzy-support

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -2,10 +2,10 @@
 #
 # Modifications by Jianbin Liu:
 # - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
-# - Pinned ros2cs to the verified Jazzy/lifecycle fix commit.
+# - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 04b8efec50e55f441f3d2973ce24e69db8de64fa
+    version: main

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -13,4 +13,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 63819bf71350b0648eb0fe8c20816deff02323c4
+    version: e0c06c3e050c1c6d50d4cae88aaa60cde04f0ed3

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -9,4 +9,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: ee32c8bfcea53786b032a81dfee2ce4ac533d46e
+    version: 5f6556628328e1a420577315842f9ae81448d9b0

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -9,4 +9,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: v0.3.1-jazzy-preview.1
+    version: v0.4.0-jazzy-preview.1

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -7,9 +7,10 @@
 # - Updated the pin to include the rosidl_python path-length root-cause fix and v0.5.0 release baseline.
 # - Updated the pin to include the generated message finalizer shutdown crash fix.
 # - Updated the pin to include ros2cs lifecycle review follow-ups and service callback compile fix.
+# - Updated the pin to include qualified generated Array.Empty calls.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 6778163f16d03457b7925d1e5a6e97f430604c9b
+    version: 63819bf71350b0648eb0fe8c20816deff02323c4

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -3,11 +3,11 @@
 # Modifications by Jianbin Liu:
 # - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
 # - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
-# - Pinned the dependency to a verified ros2cs mainline commit for reproducible public builds.
-# - Updated the pin to include the rosidl_python path-length root-cause fix.
+# - Pinned the dependency to a verified ros2cs preview tag for reproducible public builds.
+# - Updated the pin to include the rosidl_python path-length root-cause fix and v0.5.0 release baseline.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 01a44c8f07883c7aa2bbf9ed18b59b1993ef862b
+    version: v0.5.0-jazzy-preview.1

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -6,9 +6,10 @@
 # - Pinned the dependency to a verified ros2cs preview tag for reproducible public builds.
 # - Updated the pin to include the rosidl_python path-length root-cause fix and v0.5.0 release baseline.
 # - Updated the pin to include the generated message finalizer shutdown crash fix.
+# - Updated the pin to include ros2cs lifecycle review follow-ups and service callback compile fix.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 523514e336689eeed053ef3181360c19bce14143
+    version: 6778163f16d03457b7925d1e5a6e97f430604c9b

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -9,9 +9,10 @@
 # - Updated the pin to include ros2cs lifecycle review follow-ups and service callback compile fix.
 # - Updated the pin to include qualified generated Array.Empty calls.
 # - Updated the pin to include Phase 17 Unity-safe graph wait and lightweight node options.
+# - Updated the pin to include Phase 18 Lyrical spin fallback review fixes.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 632a084f0ffcc52c3b3cb5878cd1136141b98f07
+    version: d40c834b5a387838b89f372c6fbcca6706b4b9d1

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -9,4 +9,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: 636f08a8a0c12c0808aa6899208de72e1185865b
+    version: bed0b5fbbd5f33eb2750b3cd758484f6b4bd906b

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -15,4 +15,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: d40c834b5a387838b89f372c6fbcca6706b4b9d1
+    version: 66ebf542837428b8d0d6069d71f7fc07c393c1a0

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -9,4 +9,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: bed0b5fbbd5f33eb2750b3cd758484f6b4bd906b
+    version: ee32c8b7d7dacda3f20a67fe0e3cc216c47a0820

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -3,7 +3,7 @@
 # Modifications by Jianbin Liu:
 # - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
 # - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
-# - Pinned the dependency to a verified ros2cs preview tag for reproducible public builds.
+# - Pinned the dependency to a verified ros2cs preview commit hash for reproducible public builds.
 # - Updated the pin to include the rosidl_python path-length root-cause fix and v0.5.0 release baseline.
 # - Updated the pin to include the generated message finalizer shutdown crash fix.
 # - Updated the pin to include ros2cs lifecycle review follow-ups and service callback compile fix.

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -9,4 +9,4 @@ repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: ee32c8b7d7dacda3f20a67fe0e3cc216c47a0820
+    version: ee32c8bfcea53786b032a81dfee2ce4ac533d46e

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -3,9 +3,10 @@
 # Modifications by Jianbin Liu:
 # - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
 # - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
+# - Pinned the dependency to a preview tag for reproducible public builds.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: main
+    version: v0.3.1-jazzy-preview.1

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -5,9 +5,10 @@
 # - Pointed ros2cs to the JianbinLiu-CFLab mainline carrying the verified Jazzy/lifecycle fixes.
 # - Pinned the dependency to a verified ros2cs preview tag for reproducible public builds.
 # - Updated the pin to include the rosidl_python path-length root-cause fix and v0.5.0 release baseline.
+# - Updated the pin to include the generated message finalizer shutdown crash fix.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: v0.5.0-jazzy-preview.1
+    version: 523514e336689eeed053ef3181360c19bce14143

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -1,5 +1,11 @@
+# Modifications Copyright (c) 2026 Jianbin Liu.
+#
+# Modifications by Jianbin Liu:
+# - Pointed the ros2cs dependency to the JianbinLiu-CFLab fork.
+# - Pinned ros2cs to the verified Jazzy/lifecycle fix commit.
+#
 repositories:
   src/ros2cs/:
     type: git
-    url:     https://github.com/RobotecAI/ros2cs.git
-    version: feature/jazzy-support
+    url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
+    version: 04b8efec50e55f441f3d2973ce24e69db8de64fa

--- a/ros2cs.repos
+++ b/ros2cs.repos
@@ -8,9 +8,10 @@
 # - Updated the pin to include the generated message finalizer shutdown crash fix.
 # - Updated the pin to include ros2cs lifecycle review follow-ups and service callback compile fix.
 # - Updated the pin to include qualified generated Array.Empty calls.
+# - Updated the pin to include Phase 17 Unity-safe graph wait and lightweight node options.
 #
 repositories:
   src/ros2cs/:
     type: git
     url:     https://github.com/JianbinLiu-CFLab/ros2cs.git
-    version: e0c06c3e050c1c6d50d4cae88aaa60cde04f0ed3
+    version: 632a084f0ffcc52c3b3cb5878cd1136141b98f07

--- a/src/Ros2ForUnity/Scripts/PostInstall.cs
+++ b/src/Ros2ForUnity/Scripts/PostInstall.cs
@@ -48,6 +48,10 @@ internal class PostInstall : IPostprocessBuildWithReport
                 report.summary.outputPath);
         }
         var execFilename = Path.GetFileNameWithoutExtension(report.summary.outputPath);
+        var dataDir = outputDir + "/" + execFilename + "_Data";
+        var pluginsDir = dataDir + "/Plugins";
+        Directory.CreateDirectory(dataDir);
+        Directory.CreateDirectory(pluginsDir);
         if (!File.Exists(r2fuMeta) || !File.Exists(r2csMeta)) {
             throw new FileNotFoundException(
                 "Cannot copy ROS2 metadata after build. Missing source: " +
@@ -55,10 +59,10 @@ internal class PostInstall : IPostprocessBuildWithReport
         }
 
         FileUtil.CopyFileOrDirectory(
-            r2fuMeta, outputDir + "/" + execFilename + "_Data/" + r2fuMetadataName);
+            r2fuMeta, dataDir + "/" + r2fuMetadataName);
         if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.StandaloneLinux64) {
             FileUtil.CopyFileOrDirectory(
-                r2csMeta, outputDir + "/" + execFilename + "_Data/Plugins/" + r2csMetadataName);
+                r2csMeta, pluginsDir + "/" + r2csMetadataName);
 
             // Copy versioned libraries (Unity skips them)
             Regex soWithVersionReg = new Regex(@".*\.so(\.[0-9]+)+$");
@@ -67,11 +71,13 @@ internal class PostInstall : IPostprocessBuildWithReport
                                     .ToList();
             foreach (var libPath in versionedLibs) {
                 FileUtil.CopyFileOrDirectory(
-                    libPath, outputDir + "/" + execFilename + "_Data/Plugins/" + Path.GetFileName(libPath));
+                    libPath, pluginsDir + "/" + Path.GetFileName(libPath));
             }
         } else {
+            var windowsPluginsDir = pluginsDir + "/x86_64";
+            Directory.CreateDirectory(windowsPluginsDir);
             FileUtil.CopyFileOrDirectory(
-                r2csMeta, outputDir + "/" + execFilename + "_Data/Plugins/x86_64/" + r2csMetadataName);
+                r2csMeta, windowsPluginsDir + "/" + r2csMetadataName);
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/PostInstall.cs
+++ b/src/Ros2ForUnity/Scripts/PostInstall.cs
@@ -42,6 +42,11 @@ internal class PostInstall : IPostprocessBuildWithReport
         var r2fuMeta = ROS2ForUnity.GetRos2ForUnityPath() + "/" + r2fuMetadataName; 
         var r2csMeta = ROS2ForUnity.GetPluginPath() + "/" + r2csMetadataName;
         var outputDir = Directory.GetParent(report.summary.outputPath);
+        if (outputDir == null) {
+            throw new InvalidOperationException(
+                "Cannot copy ROS2 metadata after build. Build output has no parent directory: " +
+                report.summary.outputPath);
+        }
         var execFilename = Path.GetFileNameWithoutExtension(report.summary.outputPath);
         if (!File.Exists(r2fuMeta) || !File.Exists(r2csMeta)) {
             throw new FileNotFoundException(

--- a/src/Ros2ForUnity/Scripts/PostInstall.cs
+++ b/src/Ros2ForUnity/Scripts/PostInstall.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +43,12 @@ internal class PostInstall : IPostprocessBuildWithReport
         var r2csMeta = ROS2ForUnity.GetPluginPath() + "/" + r2csMetadataName;
         var outputDir = Directory.GetParent(report.summary.outputPath);
         var execFilename = Path.GetFileNameWithoutExtension(report.summary.outputPath);
+        if (!File.Exists(r2fuMeta) || !File.Exists(r2csMeta)) {
+            throw new FileNotFoundException(
+                "Cannot copy ROS2 metadata after build. Missing source: " +
+                (!File.Exists(r2fuMeta) ? r2fuMeta : r2csMeta));
+        }
+
         FileUtil.CopyFileOrDirectory(
             r2fuMeta, outputDir + "/" + execFilename + "_Data/" + r2fuMetadataName);
         if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.StandaloneLinux64) {
@@ -49,7 +56,7 @@ internal class PostInstall : IPostprocessBuildWithReport
                 r2csMeta, outputDir + "/" + execFilename + "_Data/Plugins/" + r2csMetadataName);
 
             // Copy versioned libraries (Unity skips them)
-            Regex soWithVersionReg = new Regex(@".*\.so(\.[0-9])+$");
+            Regex soWithVersionReg = new Regex(@".*\.so(\.[0-9]+)+$");
             var versionedLibs = new List<String>(Directory.GetFiles(ROS2ForUnity.GetPluginPath()))
                                     .Where(path => soWithVersionReg.IsMatch(path))
                                     .ToList();

--- a/src/Ros2ForUnity/Scripts/PostInstall.cs.meta
+++ b/src/Ros2ForUnity/Scripts/PostInstall.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b2faaa8ccfc49c3b934181fe43c7b7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
@@ -77,38 +77,6 @@ public class ROS2ClientExample : MonoBehaviour
         }
     }
 
-    IEnumerator periodicCall()
-    {
-        while (ros2Unity != null && ros2Unity.Ok())
-        {
-            if (addTwoIntsClient == null)
-            {
-                yield return new WaitForSecondsRealtime(1);
-                continue;
-            }
-
-            while (ros2Unity != null && ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
-            {
-                yield return new WaitForSecondsRealtime(1);
-            }
-
-            if (ros2Unity == null || !ros2Unity.Ok() || addTwoIntsClient == null)
-            {
-                yield break;
-            }
-
-            addTwoIntsReq request = new addTwoIntsReq();
-            request.A = Random.Range(0, 100);
-            request.B = Random.Range(0, 100);
-            // Example-only synchronous call. Production Unity code should prefer CallAsync to avoid blocking frames.
-            var response = addTwoIntsClient.Call(request);
-
-            Debug.Log("Got sync answer " + response.Sum);
-
-            yield return new WaitForSecondsRealtime(1);
-        }
-    }
-
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
@@ -148,11 +116,7 @@ public class ROS2ClientExample : MonoBehaviour
         {
             isRunning = true;
 
-            // Async calls
             StartCoroutine(RunTracked(periodicAsyncCall()));
-
-            // Sync calls
-            StartCoroutine(RunTracked(periodicCall()));
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
@@ -31,6 +31,7 @@ public class ROS2ClientExample : MonoBehaviour
     private ROS2Node ros2Node;
     private IClient<addTwoIntsReq, addTwoIntsResp> addTwoIntsClient;
     private bool isRunning = false;
+    private int runningCoroutines = 0;
     private Task<addTwoIntsResp> asyncTask;
 
     IEnumerator periodicAsyncCall()
@@ -99,6 +100,7 @@ public class ROS2ClientExample : MonoBehaviour
             addTwoIntsReq request = new addTwoIntsReq();
             request.A = Random.Range(0, 100);
             request.B = Random.Range(0, 100);
+            // Example-only synchronous call. Production Unity code should prefer CallAsync to avoid blocking frames.
             var response = addTwoIntsClient.Call(request);
 
             Debug.Log("Got sync answer " + response.Sum);
@@ -138,10 +140,28 @@ public class ROS2ClientExample : MonoBehaviour
             isRunning = true;
 
             // Async calls
-            StartCoroutine(periodicAsyncCall());
+            StartCoroutine(RunTracked(periodicAsyncCall()));
 
             // Sync calls
-            StartCoroutine(periodicCall());
+            StartCoroutine(RunTracked(periodicCall()));
+        }
+    }
+
+    private IEnumerator RunTracked(IEnumerator routine)
+    {
+        runningCoroutines++;
+        try
+        {
+            yield return StartCoroutine(routine);
+        }
+        finally
+        {
+            runningCoroutines--;
+            if (runningCoroutines <= 0)
+            {
+                runningCoroutines = 0;
+                isRunning = false;
+            }
         }
     }
 }

--- a/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
@@ -36,7 +36,7 @@ public class ROS2ClientExample : MonoBehaviour
 
     IEnumerator periodicAsyncCall()
     {
-        while (ros2Unity.Ok())
+        while (ros2Unity != null && ros2Unity.Ok())
         {
             if (addTwoIntsClient == null)
             {
@@ -44,12 +44,12 @@ public class ROS2ClientExample : MonoBehaviour
                 continue;
             }
 
-            while (ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
+            while (ros2Unity != null && ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
             {
                 yield return new WaitForSecondsRealtime(1);
             }
 
-            if (!ros2Unity.Ok() || addTwoIntsClient == null)
+            if (ros2Unity == null || !ros2Unity.Ok() || addTwoIntsClient == null)
             {
                 yield break;
             }
@@ -59,7 +59,7 @@ public class ROS2ClientExample : MonoBehaviour
             request.B = Random.Range(0, 100);
             
             asyncTask = addTwoIntsClient.CallAsync(request);
-            yield return new WaitUntil(() => asyncTask.IsCompleted || !ros2Unity.Ok());
+            yield return new WaitUntil(() => asyncTask.IsCompleted || ros2Unity == null || !ros2Unity.Ok());
             if (!asyncTask.IsCompleted)
             {
                 yield break;
@@ -79,7 +79,7 @@ public class ROS2ClientExample : MonoBehaviour
 
     IEnumerator periodicCall()
     {
-        while (ros2Unity.Ok())
+        while (ros2Unity != null && ros2Unity.Ok())
         {
             if (addTwoIntsClient == null)
             {
@@ -87,12 +87,12 @@ public class ROS2ClientExample : MonoBehaviour
                 continue;
             }
 
-            while (ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
+            while (ros2Unity != null && ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
             {
                 yield return new WaitForSecondsRealtime(1);
             }
 
-            if (!ros2Unity.Ok() || addTwoIntsClient == null)
+            if (ros2Unity == null || !ros2Unity.Ok() || addTwoIntsClient == null)
             {
                 yield break;
             }
@@ -112,10 +112,19 @@ public class ROS2ClientExample : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+        if (ros2Unity == null)
+        {
+            Debug.LogError("ROS2ClientExample requires ROS2UnityComponent on the same GameObject.");
+        }
     }
 
     private void EnsureClient()
     {
+        if (ros2Unity == null)
+        {
+            return;
+        }
+
         if (ros2Unity.Ok())
         {
             if (ros2Node == null)

--- a/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
@@ -33,6 +33,7 @@ public class ROS2ClientExample : MonoBehaviour
     private bool isRunning = false;
     private int runningCoroutines = 0;
     private Task<addTwoIntsResp> asyncTask;
+    private readonly WaitForSecondsRealtime waitOneSecond = new WaitForSecondsRealtime(1);
 
     IEnumerator periodicAsyncCall()
     {
@@ -40,13 +41,13 @@ public class ROS2ClientExample : MonoBehaviour
         {
             if (addTwoIntsClient == null)
             {
-                yield return new WaitForSecondsRealtime(1);
+                yield return waitOneSecond;
                 continue;
             }
 
             while (ros2Unity != null && ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
             {
-                yield return new WaitForSecondsRealtime(1);
+                yield return waitOneSecond;
             }
 
             if (ros2Unity == null || !ros2Unity.Ok() || addTwoIntsClient == null)
@@ -73,7 +74,7 @@ public class ROS2ClientExample : MonoBehaviour
                 Debug.Log("Got async answer " + asyncTask.Result.Sum);
             }
             
-            yield return new WaitForSecondsRealtime(1);
+            yield return waitOneSecond;
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,10 +37,20 @@ public class ROS2ClientExample : MonoBehaviour
     {
         while (ros2Unity.Ok())
         {
-
-            while (!addTwoIntsClient.IsServiceAvailable())
+            if (addTwoIntsClient == null)
             {
                 yield return new WaitForSecondsRealtime(1);
+                continue;
+            }
+
+            while (ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
+            {
+                yield return new WaitForSecondsRealtime(1);
+            }
+
+            if (!ros2Unity.Ok() || addTwoIntsClient == null)
+            {
+                yield break;
             }
 
             addTwoIntsReq request = new addTwoIntsReq();
@@ -47,7 +58,19 @@ public class ROS2ClientExample : MonoBehaviour
             request.B = Random.Range(0, 100);
             
             asyncTask = addTwoIntsClient.CallAsync(request);
-            asyncTask.ContinueWith((task) => { Debug.Log("Got async answer " + task.Result.Sum); });
+            yield return new WaitUntil(() => asyncTask.IsCompleted || !ros2Unity.Ok());
+            if (!asyncTask.IsCompleted)
+            {
+                yield break;
+            }
+            if (asyncTask.IsFaulted)
+            {
+                Debug.LogException(asyncTask.Exception);
+            }
+            else if (!asyncTask.IsCanceled)
+            {
+                Debug.Log("Got async answer " + asyncTask.Result.Sum);
+            }
             
             yield return new WaitForSecondsRealtime(1);
         }
@@ -57,10 +80,20 @@ public class ROS2ClientExample : MonoBehaviour
     {
         while (ros2Unity.Ok())
         {
-
-            while (!addTwoIntsClient.IsServiceAvailable())
+            if (addTwoIntsClient == null)
             {
                 yield return new WaitForSecondsRealtime(1);
+                continue;
+            }
+
+            while (ros2Unity.Ok() && addTwoIntsClient != null && !addTwoIntsClient.IsServiceAvailable())
+            {
+                yield return new WaitForSecondsRealtime(1);
+            }
+
+            if (!ros2Unity.Ok() || addTwoIntsClient == null)
+            {
+                yield break;
             }
 
             addTwoIntsReq request = new addTwoIntsReq();
@@ -77,6 +110,10 @@ public class ROS2ClientExample : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+    }
+
+    private void EnsureClient()
+    {
         if (ros2Unity.Ok())
         {
             if (ros2Node == null)
@@ -90,6 +127,12 @@ public class ROS2ClientExample : MonoBehaviour
 
     void Update()
     {
+        EnsureClient();
+        if (addTwoIntsClient == null)
+        {
+            return;
+        }
+
         if (!isRunning)
         {
             isRunning = true;

--- a/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs.meta
+++ b/src/Ros2ForUnity/Scripts/ROS2ClientExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc7371025b134a2c82932e84c0cd05e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -39,8 +39,9 @@ internal class ROS2ForUnity : IDisposable
 #if UNITY_EDITOR
     private static bool editorHandlersRegistered = false;
 #endif
-    private XmlDocument ros2csMetadata = new XmlDocument();
-    private XmlDocument ros2ForUnityMetadata = new XmlDocument();
+    // Metadata files are local package files; disable external XML resolution defensively.
+    private XmlDocument ros2csMetadata = new XmlDocument { XmlResolver = null };
+    private XmlDocument ros2ForUnityMetadata = new XmlDocument { XmlResolver = null };
     private bool ownsReference = false;
 
     public enum Platform
@@ -175,8 +176,9 @@ internal class ROS2ForUnity : IDisposable
         pathConfigured = true;
     }
 
-    public bool IsStandalone() {
-        return Convert.ToBoolean(Convert.ToInt16(GetMetadataValue(ros2csMetadata, "/ros2cs/standalone")));
+    public bool IsStandalone()
+    {
+        return ParseMetadataBool(GetMetadataValue(ros2csMetadata, "/ros2cs/standalone"), "/ros2cs/standalone");
     }
 
     public string GetROSVersion()
@@ -309,6 +311,25 @@ internal class ROS2ForUnity : IDisposable
         }
 
         return node.InnerText;
+    }
+
+    private bool ParseMetadataBool(string value, string valuePath)
+    {
+        string normalized = value.Trim();
+        if (normalized == "1")
+        {
+            return true;
+        }
+        if (normalized == "0")
+        {
+            return false;
+        }
+        if (bool.TryParse(normalized, out bool parsed))
+        {
+            return parsed;
+        }
+
+        throw new InvalidOperationException("Metadata value is not a boolean: " + valuePath + " = " + value);
     }
 
     private void LoadMetadata() 

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +17,9 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.Xml;
 
 namespace ROS2
@@ -25,12 +28,20 @@ namespace ROS2
 /// <summary>
 /// An internal class responsible for handling checking, proper initialization and shutdown of ROS2cs,
 /// </summary>
-internal class ROS2ForUnity
+internal class ROS2ForUnity : IDisposable
 {
     private static bool isInitialized = false;
+    private static readonly object initMutex = new object();
+    private static int referenceCount = 0;
+    private static bool pathConfigured = false;
     private static string ros2ForUnityAssetFolderName = "Ros2ForUnity";
+    private static ConsoleCancelEventHandler consoleCancelHandler;
+#if UNITY_EDITOR
+    private static bool editorHandlersRegistered = false;
+#endif
     private XmlDocument ros2csMetadata = new XmlDocument();
     private XmlDocument ros2ForUnityMetadata = new XmlDocument();
+    private bool ownsReference = false;
 
     public enum Platform
     {
@@ -133,14 +144,35 @@ internal class ROS2ForUnity
     {
         string currentPath = GetEnvPathVariableValue();
         string pluginPath = GetPluginPath();
-        
+
         char envPathSep = ':';
         if (GetOS() == Platform.Windows)
         {
             envPathSep = ';';
         }
 
+        if (String.IsNullOrEmpty(currentPath))
+        {
+            Environment.SetEnvironmentVariable(GetEnvPathVariableName(), pluginPath);
+            pathConfigured = true;
+            return;
+        }
+
+        StringComparison comparison = GetOS() == Platform.Windows
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        foreach (string entry in currentPath.Split(envPathSep))
+        {
+            if (String.Equals(entry.Trim(), pluginPath, comparison))
+            {
+                pathConfigured = true;
+                return;
+            }
+        }
+
         Environment.SetEnvironmentVariable(GetEnvPathVariableName(), pluginPath + envPathSep + currentPath);
+        pathConfigured = true;
     }
 
     public bool IsStandalone() {
@@ -171,24 +203,25 @@ internal class ROS2ForUnity
         string ros2FromRos4UMetadata = GetMetadataValue(ros2ForUnityMetadata, "/ros2_for_unity/ros2");
 
         if (ros2FromRos4UMetadata != ros2FromRos2csMetadata) {
-            Debug.LogError(
+            string errMessage =
                 "ROS2 versions in 'ros2cs' and 'ros2-for-unity' metadata files are not the same. " +
-                "This is caused by mixing versions/builds. Plugin might not work correctly."
-            );
+                "This is caused by mixing versions/builds.";
+            Debug.LogError(errMessage);
+            throw new InvalidOperationException(errMessage);
         }
 
         if(!IsStandalone() && ros2SourcedCodename != ros2FromRos2csMetadata) {
-            Debug.LogError(
+            string errMessage =
                 "ROS2 version in 'ros2cs' metadata doesn't match currently sourced version. " +
-                "This is caused by mixing versions/builds. Plugin might not work correctly."
-            );
+                "This is caused by mixing versions/builds.";
+            Debug.LogError(errMessage);
+            throw new InvalidOperationException(errMessage);
         }
 
         if (IsStandalone() && !string.IsNullOrEmpty(ros2SourcedCodename)) {
-            Debug.LogError(
-                "You should not source ROS2 in 'ros2-for-unity' standalone build. " +
-                "Plugin might not work correctly."
-            );
+            string errMessage = "You should not source ROS2 in 'ros2-for-unity' standalone build.";
+            Debug.LogError(errMessage);
+            throw new InvalidOperationException(errMessage);
         }
     }
 
@@ -216,6 +249,7 @@ internal class ROS2ForUnity
 #else
             const int ROS_NOT_SOURCED_ERROR_CODE = 33;
             Application.Quit(ROS_NOT_SOURCED_ERROR_CODE);
+            throw new System.InvalidOperationException(errMessage);
 #endif
         }
 
@@ -230,6 +264,7 @@ internal class ROS2ForUnity
 #else
             const int ROS_BAD_VERSION_CODE = 34;
             Application.Quit(ROS_BAD_VERSION_CODE);
+            throw new System.NotSupportedException(errMessage);
 #endif
         } else if (ros2Codename.Equals("rolling") ) {
             Debug.LogWarning("You are using ROS2 rolling version. Bleeding edge version might not work correctly.");
@@ -240,10 +275,14 @@ internal class ROS2ForUnity
     {
 #if ENABLE_MONO
         // Il2CPP build does not support Console.CancelKeyPress currently
-        Console.CancelKeyPress += (sender, eventArgs) => {
-            eventArgs.Cancel = true;
-            DestroyROS2ForUnity();
-        };
+        if (consoleCancelHandler == null)
+        {
+            consoleCancelHandler = (sender, eventArgs) => {
+                eventArgs.Cancel = true;
+                ShutdownShared();
+            };
+            Console.CancelKeyPress += consoleCancelHandler;
+        }
 #endif
     }
 
@@ -258,7 +297,18 @@ internal class ROS2ForUnity
 
     private string GetMetadataValue(XmlDocument doc, string valuePath)
     {
-        return doc.DocumentElement.SelectSingleNode(valuePath).InnerText;
+        if (doc.DocumentElement == null)
+        {
+            throw new InvalidOperationException("Metadata document is empty while reading " + valuePath);
+        }
+
+        XmlNode node = doc.DocumentElement.SelectSingleNode(valuePath);
+        if (node == null || node.InnerText == null)
+        {
+            throw new InvalidOperationException("Metadata value missing: " + valuePath);
+        }
+
+        return node.InnerText;
     }
 
     private void LoadMetadata() 
@@ -278,48 +328,74 @@ internal class ROS2ForUnity
 #else
             const int NO_METADATA = 1;
             Application.Quit(NO_METADATA);
+            throw;
 #endif
+        }
+        catch (XmlException e)
+        {
+            string errMessage = "Could not parse ros2-for-unity metadata: " + e.Message;
+#if UNITY_EDITOR
+            EditorApplication.isPlaying = false;
+#else
+            const int BAD_METADATA = 2;
+            Application.Quit(BAD_METADATA);
+#endif
+            throw new InvalidOperationException(errMessage, e);
         }
     }
 
     internal ROS2ForUnity()
     {
-        // Load metadata
-        LoadMetadata();
-        string currentRos2Version = GetROSVersion();
-        string standalone = IsStandalone() ? "standalone" : "non-standalone";
-
-        // Self checks
-        CheckROSSupport(currentRos2Version);
-        CheckIntegrity();
-
-        // Library loading
-        if (GetOS() == Platform.Windows) {
-            // Windows version can run standalone, modifies PATH to ensure all plugins visibility
-            SetEnvPathVariable();
-        } else {
-            // For foxy, it is necessary to use modified version of librcpputils to resolve custom msgs packages.
-            ROS2.GlobalVariables.absolutePath = GetPluginPath() + "/";
-            if (currentRos2Version == "foxy") {
-                ROS2.GlobalVariables.preloadLibrary = true;
-                ROS2.GlobalVariables.preloadLibraryName = "librcpputils.so";
+        lock (initMutex)
+        {
+            if (isInitialized)
+            {
+                referenceCount++;
+                ownsReference = true;
+                return;
             }
-        }
 
-        // Initialize
-        ConnectLoggers();
-        Ros2cs.Init();
-        RegisterCtrlCHandler();
+            // Load metadata
+            LoadMetadata();
+            string currentRos2Version = GetROSVersion();
+            string standalone = IsStandalone() ? "standalone" : "non-standalone";
 
-        string rmwImpl = Ros2cs.GetRMWImplementation();
+            // Self checks
+            CheckROSSupport(currentRos2Version);
+            CheckIntegrity();
 
-        Debug.Log("ROS2 version: " + currentRos2Version + ". Build type: " + standalone + ". RMW: " + rmwImpl);
+            // Library loading
+            if (GetOS() == Platform.Windows) {
+                // Windows version can run standalone, modifies PATH to ensure all plugins visibility.
+                if (!pathConfigured)
+                {
+                    SetEnvPathVariable();
+                }
+            } else {
+                // For foxy, it is necessary to use modified version of librcpputils to resolve custom msgs packages.
+                ROS2.GlobalVariables.absolutePath = GetPluginPath() + "/";
+                if (currentRos2Version == "foxy") {
+                    ROS2.GlobalVariables.preloadLibrary = true;
+                    ROS2.GlobalVariables.preloadLibraryName = "librcpputils.so";
+                }
+            }
+
+            // Initialize
+            ConnectLoggers();
+            Ros2cs.Init();
+            RegisterCtrlCHandler();
+
+            string rmwImpl = Ros2cs.GetRMWImplementation();
+
+            Debug.Log("ROS2 version: " + currentRos2Version + ". Build type: " + standalone + ". RMW: " + rmwImpl);
 
 #if UNITY_EDITOR
-        EditorApplication.playModeStateChanged += this.EditorPlayStateChanged;
-        EditorApplication.quitting += this.DestroyROS2ForUnity;
+            RegisterEditorHandlers();
 #endif
-        isInitialized = true;
+            isInitialized = true;
+            referenceCount = 1;
+            ownsReference = true;
+        }
     }
 
     private static void ThrowIfUninitialized(string callContext)
@@ -336,34 +412,115 @@ internal class ROS2ForUnity
     /// <returns>The state of ROS2 module. Should be checked before attempting to create or use pubs/subs</returns>
     public bool Ok()
     {
-        if (!isInitialized)
+        lock (initMutex)
         {
-            return false;
+            if (!isInitialized)
+            {
+                return false;
+            }
+            return Ros2cs.Ok();
         }
-        return Ros2cs.Ok();
     }
-
     internal void DestroyROS2ForUnity()
     {
-        if (isInitialized)
+        lock (initMutex)
         {
-            Debug.Log("Shutting down Ros2 For Unity");
-            Ros2cs.Shutdown();
-            isInitialized = false;
+            if (!ownsReference)
+            {
+                return;
+            }
+
+            ownsReference = false;
+            if (referenceCount > 0)
+            {
+                referenceCount--;
+            }
+
+            if (referenceCount == 0)
+            {
+                ShutdownShared();
+            }
         }
     }
 
-    ~ROS2ForUnity()
+    public void Dispose()
     {
         DestroyROS2ForUnity();
+        GC.SuppressFinalize(this);
+    }
+
+    private static void ShutdownShared()
+    {
+        lock (initMutex)
+        {
+            if (!isInitialized)
+            {
+                referenceCount = 0;
+                return;
+            }
+
+            Debug.Log("Shutting down Ros2 For Unity");
+            try
+            {
+#if UNITY_EDITOR
+                UnregisterEditorHandlers();
+#endif
+                Ros2cs.Shutdown();
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            finally
+            {
+                isInitialized = false;
+                referenceCount = 0;
+                UnregisterCtrlCHandlerStatic();
+            }
+        }
+    }
+
+    private static void UnregisterCtrlCHandlerStatic()
+    {
+#if ENABLE_MONO
+        if (consoleCancelHandler != null)
+        {
+            Console.CancelKeyPress -= consoleCancelHandler;
+            consoleCancelHandler = null;
+        }
+#endif
     }
 
 #if UNITY_EDITOR
-    void EditorPlayStateChanged(PlayModeStateChange change)
+    private static void RegisterEditorHandlers()
+    {
+        if (editorHandlersRegistered)
+        {
+            return;
+        }
+
+        EditorApplication.playModeStateChanged += EditorPlayStateChanged;
+        EditorApplication.quitting += ShutdownShared;
+        editorHandlersRegistered = true;
+    }
+
+    private static void UnregisterEditorHandlers()
+    {
+        if (!editorHandlersRegistered)
+        {
+            return;
+        }
+
+        EditorApplication.playModeStateChanged -= EditorPlayStateChanged;
+        EditorApplication.quitting -= ShutdownShared;
+        editorHandlersRegistered = false;
+    }
+
+    private static void EditorPlayStateChanged(PlayModeStateChange change)
     {
         if (change == PlayModeStateChange.ExitingPlayMode)
         {
-            DestroyROS2ForUnity();
+            ShutdownShared();
         }
     }
 #endif

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -213,23 +213,33 @@ internal class ROS2ForUnity : IDisposable
             string errMessage =
                 "ROS2 versions in 'ros2cs' and 'ros2-for-unity' metadata files are not the same. " +
                 "This is caused by mixing versions/builds.";
-            Debug.LogError(errMessage);
-            throw new InvalidOperationException(errMessage);
+            FailIntegrity(errMessage);
         }
 
         if(!IsStandalone() && ros2SourcedCodename != ros2FromRos2csMetadata) {
             string errMessage =
                 "ROS2 version in 'ros2cs' metadata doesn't match currently sourced version. " +
                 "This is caused by mixing versions/builds.";
-            Debug.LogError(errMessage);
-            throw new InvalidOperationException(errMessage);
+            FailIntegrity(errMessage);
         }
 
         if (IsStandalone() && !string.IsNullOrEmpty(ros2SourcedCodename)) {
             string errMessage = "You should not source ROS2 in 'ros2-for-unity' standalone build.";
-            Debug.LogError(errMessage);
-            throw new InvalidOperationException(errMessage);
+            FailIntegrity(errMessage);
         }
+    }
+
+    private static void FailIntegrity(string errMessage)
+    {
+        Debug.LogError(errMessage);
+#if UNITY_EDITOR
+        EditorApplication.isPlaying = false;
+        throw new InvalidOperationException(errMessage);
+#else
+        const int ROS_METADATA_MISMATCH_ERROR_CODE = 35;
+        Application.Quit(ROS_METADATA_MISMATCH_ERROR_CODE);
+        throw new InvalidOperationException(errMessage);
+#endif
     }
 
     public string GetROSVersionSourced()
@@ -272,6 +282,8 @@ internal class ROS2ForUnity : IDisposable
             Application.Quit(ROS_BAD_VERSION_CODE);
             throw new System.NotSupportedException(errMessage);
 #endif
+        } else if (ros2Codename.Equals("foxy") || ros2Codename.Equals("galactic")) {
+            Debug.LogWarning("You are using ROS2 " + ros2Codename + ", which has reached end of life.");
         } else if (ros2Codename.Equals("rolling") ) {
             Debug.LogWarning("You are using ROS2 rolling version. Bleeding edge version might not work correctly.");
         }

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -212,8 +212,13 @@ internal class ROS2ForUnity : IDisposable
     private static void SetStandalonePrefixPath()
     {
         string prefixPath = GetRos2ForUnityPath();
+        string streamingAssetsPrefixPath = Path.Combine(Application.streamingAssetsPath, ros2ForUnityAssetFolderName);
         string pluginPrefixPath = GetPluginPath();
-        if (Directory.Exists(Path.Combine(pluginPrefixPath, "share")))
+        if (Directory.Exists(Path.Combine(streamingAssetsPrefixPath, "share")))
+        {
+            prefixPath = streamingAssetsPrefixPath;
+        }
+        else if (Directory.Exists(Path.Combine(pluginPrefixPath, "share")))
         {
             prefixPath = pluginPrefixPath;
         }

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -35,6 +35,7 @@ internal class ROS2ForUnity : IDisposable
     private static int referenceCount = 0;
     private static bool pathConfigured = false;
     private static string ros2ForUnityAssetFolderName = "Ros2ForUnity";
+    private static readonly List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "jazzy", "rolling" };
     private static ConsoleCancelEventHandler consoleCancelHandler;
 #if UNITY_EDITOR
     private static bool editorHandlersRegistered = false;
@@ -80,7 +81,7 @@ internal class ROS2ForUnity : IDisposable
         }
     }
     
-    private string GetEnvPathVariableName()
+    private static string GetEnvPathVariableName()
     {
       string envVariable = "LD_LIBRARY_PATH";
       if (GetOS() == Platform.Windows)
@@ -90,7 +91,7 @@ internal class ROS2ForUnity : IDisposable
       return envVariable;
     }
 
-    private string GetEnvPathVariableValue()
+    private static string GetEnvPathVariableValue()
     {
         return Environment.GetEnvironmentVariable(GetEnvPathVariableName());
     }
@@ -112,7 +113,11 @@ internal class ROS2ForUnity : IDisposable
         char separator = Path.DirectorySeparatorChar;
         string ros2ForUnityPath = GetRos2ForUnityPath();
         string pluginPath = ros2ForUnityPath;
-        
+
+        // Editor: Assets/Ros2ForUnity/Plugins/<OS>/x86_64
+        // Windows Player: <App>_Data/Plugins/x86_64
+        // Linux Player: <App>_Data/Plugins
+
         pluginPath += separator + "Plugins";
         
         if (InEditor()) {
@@ -141,7 +146,7 @@ internal class ROS2ForUnity : IDisposable
     /// is effective for this process, however rmw implementation's dependencies itself are loaded by dynamic linker 
     /// anyway so setting it for Linux is pointless.
     /// </description>
-    private void SetEnvPathVariable()
+    private static void SetEnvPathVariable()
     {
         string currentPath = GetEnvPathVariableValue();
         string pluginPath = GetPluginPath();
@@ -238,7 +243,6 @@ internal class ROS2ForUnity : IDisposable
     /// </summary>
     private void CheckROSSupport(string ros2Codename)
     {
-        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "jazzy", "rolling" };
         var supportedVersionsString = String.Join(", ", supportedVersions);
         if (string.IsNullOrEmpty(ros2Codename))
         {
@@ -337,15 +341,17 @@ internal class ROS2ForUnity : IDisposable
         char separator = Path.DirectorySeparatorChar;
         try
         {
-            ros2csMetadata.Load(GetPluginPath() + separator + "metadata_ros2cs.xml");
-            ros2ForUnityMetadata.Load(GetRos2ForUnityPath() + separator + "metadata_ros2_for_unity.xml");
+            string ros2csMetadataPath = GetPluginPath() + separator + "metadata_ros2cs.xml";
+            string ros2ForUnityMetadataPath = GetRos2ForUnityPath() + separator + "metadata_ros2_for_unity.xml";
+            ros2csMetadata.Load(ros2csMetadataPath);
+            ros2ForUnityMetadata.Load(ros2ForUnityMetadataPath);
         }
-        catch (System.IO.FileNotFoundException)
+        catch (System.IO.FileNotFoundException e)
         {
 #if UNITY_EDITOR
-            var errMessage = "Could not find metadata files.";
+            var errMessage = "Could not find metadata files: " + e.Message;
             EditorApplication.isPlaying = false;
-            throw new System.IO.FileNotFoundException(errMessage);
+            throw new System.IO.FileNotFoundException(errMessage, e);
 #else
             const int NO_METADATA = 1;
             Application.Quit(NO_METADATA);

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -35,7 +35,11 @@ internal class ROS2ForUnity : IDisposable
     private static int referenceCount = 0;
     private static bool pathConfigured = false;
     private static string ros2ForUnityAssetFolderName = "Ros2ForUnity";
-    private static readonly List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "jazzy", "rolling" };
+    private static readonly string[] supportedVersionsOrdered = { "foxy", "galactic", "humble", "jazzy", "rolling" };
+    private static readonly HashSet<string> supportedVersions = new HashSet<string>(supportedVersionsOrdered);
+    private static readonly string supportedVersionsString = String.Join(", ", supportedVersionsOrdered);
+    private static readonly Lazy<string> ros2ForUnityPath = new Lazy<string>(ComputeRos2ForUnityPath);
+    private static readonly Lazy<string> pluginPath = new Lazy<string>(ComputePluginPath);
     private static ConsoleCancelEventHandler consoleCancelHandler;
 #if UNITY_EDITOR
     private static bool editorHandlersRegistered = false;
@@ -98,43 +102,53 @@ internal class ROS2ForUnity : IDisposable
 
     public static string GetRos2ForUnityPath()
     {
+        return ros2ForUnityPath.Value;
+    }
+
+    private static string ComputeRos2ForUnityPath()
+    {
         char separator = Path.DirectorySeparatorChar;
         string appDataPath = Application.dataPath;
-        string pluginPath = appDataPath;
+        string path = appDataPath;
 
         if (InEditor()) {
-            pluginPath += separator + ros2ForUnityAssetFolderName;
+            path += separator + ros2ForUnityAssetFolderName;
         }
-        return pluginPath; 
+        return path;
     }
 
     public static string GetPluginPath()
     {
+        return pluginPath.Value;
+    }
+
+    private static string ComputePluginPath()
+    {
         char separator = Path.DirectorySeparatorChar;
         string ros2ForUnityPath = GetRos2ForUnityPath();
-        string pluginPath = ros2ForUnityPath;
+        string path = ros2ForUnityPath;
 
         // Editor: Assets/Ros2ForUnity/Plugins/<OS>/x86_64
         // Windows Player: <App>_Data/Plugins/x86_64
         // Linux Player: <App>_Data/Plugins
 
-        pluginPath += separator + "Plugins";
-        
+        path += separator + "Plugins";
+
         if (InEditor()) {
-            pluginPath += separator + GetOSName();
+            path += separator + GetOSName();
         }
 
         if (InEditor() || GetOS() == Platform.Windows)
         {
-           pluginPath += separator + "x86_64";
-        }
-        
-        if (GetOS() == Platform.Windows)
-        {
-           pluginPath = pluginPath.Replace("/", "\\");
+           path += separator + "x86_64";
         }
 
-        return pluginPath;
+        if (GetOS() == Platform.Windows)
+        {
+           path = path.Replace("/", "\\");
+        }
+
+        return path;
     }
 
     /// <summary>
@@ -253,7 +267,6 @@ internal class ROS2ForUnity : IDisposable
     /// </summary>
     private void CheckROSSupport(string ros2Codename)
     {
-        var supportedVersionsString = String.Join(", ", supportedVersions);
         if (string.IsNullOrEmpty(ros2Codename))
         {
             string errMessage = "No ROS environment sourced. You need to source your ROS2 " + supportedVersionsString

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -203,7 +203,7 @@ internal class ROS2ForUnity
     /// </summary>
     private void CheckROSSupport(string ros2Codename)
     {
-        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "rolling" };
+        List<string> supportedVersions = new List<string>() { "foxy", "galactic", "humble", "jazzy", "rolling" };
         var supportedVersionsString = String.Join(", ", supportedVersions);
         if (string.IsNullOrEmpty(ros2Codename))
         {

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -35,12 +36,16 @@ internal class ROS2ForUnity : IDisposable
     private static int referenceCount = 0;
     private static bool pathConfigured = false;
     private static string ros2ForUnityAssetFolderName = "Ros2ForUnity";
-    private static readonly string[] supportedVersionsOrdered = { "foxy", "galactic", "humble", "jazzy", "rolling" };
+    private static readonly string[] supportedVersionsOrdered = { "foxy", "galactic", "humble", "jazzy", "lyrical", "rolling" };
     private static readonly HashSet<string> supportedVersions = new HashSet<string>(supportedVersionsOrdered);
     private static readonly string supportedVersionsString = String.Join(", ", supportedVersionsOrdered);
     private static readonly Lazy<string> ros2ForUnityPath = new Lazy<string>(ComputeRos2ForUnityPath);
     private static readonly Lazy<string> pluginPath = new Lazy<string>(ComputePluginPath);
     private static ConsoleCancelEventHandler consoleCancelHandler;
+
+    [DllImport("ucrtbase.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    private static extern int _putenv_s(string name, string value);
+
 #if UNITY_EDITOR
     private static bool editorHandlersRegistered = false;
 #endif
@@ -98,6 +103,15 @@ internal class ROS2ForUnity : IDisposable
     private static string GetEnvPathVariableValue()
     {
         return Environment.GetEnvironmentVariable(GetEnvPathVariableName());
+    }
+
+    private static void SetProcessEnvironmentVariable(string name, string value)
+    {
+        Environment.SetEnvironmentVariable(name, value);
+        if (GetOS() == Platform.Windows)
+        {
+            _putenv_s(name, value);
+        }
     }
 
     public static string GetRos2ForUnityPath()
@@ -173,7 +187,7 @@ internal class ROS2ForUnity : IDisposable
 
         if (String.IsNullOrEmpty(currentPath))
         {
-            Environment.SetEnvironmentVariable(GetEnvPathVariableName(), pluginPath);
+            SetProcessEnvironmentVariable(GetEnvPathVariableName(), pluginPath);
             pathConfigured = true;
             return;
         }
@@ -191,8 +205,64 @@ internal class ROS2ForUnity : IDisposable
             }
         }
 
-        Environment.SetEnvironmentVariable(GetEnvPathVariableName(), pluginPath + envPathSep + currentPath);
+        SetProcessEnvironmentVariable(GetEnvPathVariableName(), pluginPath + envPathSep + currentPath);
         pathConfigured = true;
+    }
+
+    private static void SetStandalonePrefixPath()
+    {
+        string prefixPath = GetRos2ForUnityPath();
+        string pluginPrefixPath = GetPluginPath();
+        if (Directory.Exists(Path.Combine(pluginPrefixPath, "share")))
+        {
+            prefixPath = pluginPrefixPath;
+        }
+        string currentPrefixPath = Environment.GetEnvironmentVariable("AMENT_PREFIX_PATH");
+        char envPathSep = GetOS() == Platform.Windows ? ';' : ':';
+
+        if (String.IsNullOrEmpty(currentPrefixPath))
+        {
+            SetProcessEnvironmentVariable("AMENT_PREFIX_PATH", prefixPath);
+            return;
+        }
+
+        StringComparison comparison = GetOS() == Platform.Windows
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        foreach (string entry in currentPrefixPath.Split(envPathSep))
+        {
+            if (String.Equals(entry.Trim(), prefixPath, comparison))
+            {
+                return;
+            }
+        }
+
+        SetProcessEnvironmentVariable("AMENT_PREFIX_PATH", prefixPath + envPathSep + currentPrefixPath);
+    }
+
+    private static void SetStandaloneRmwImplementation()
+    {
+        if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("RMW_IMPLEMENTATION")))
+        {
+            SetProcessEnvironmentVariable("RMW_IMPLEMENTATION", "rmw_fastrtps_cpp");
+        }
+    }
+
+    private static void SetStandaloneRosDistro(string ros2Codename)
+    {
+        if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("ROS_DISTRO")))
+        {
+            SetProcessEnvironmentVariable("ROS_DISTRO", ros2Codename);
+        }
+    }
+
+    private static void SetStandaloneRcutilsConsoleMode()
+    {
+        if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("RCUTILS_COLORIZED_OUTPUT")))
+        {
+            SetProcessEnvironmentVariable("RCUTILS_COLORIZED_OUTPUT", "0");
+        }
     }
 
     public bool IsStandalone()
@@ -422,6 +492,13 @@ internal class ROS2ForUnity : IDisposable
                 if (!pathConfigured)
                 {
                     SetEnvPathVariable();
+                }
+                if (IsStandalone())
+                {
+                    SetStandaloneRosDistro(currentRos2Version);
+                    SetStandalonePrefixPath();
+                    SetStandaloneRmwImplementation();
+                    SetStandaloneRcutilsConsoleMode();
                 }
             } else {
                 // For foxy, it is necessary to use modified version of librcpputils to resolve custom msgs packages.

--- a/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ForUnity.cs
@@ -42,9 +42,10 @@ internal class ROS2ForUnity : IDisposable
     private static readonly Lazy<string> ros2ForUnityPath = new Lazy<string>(ComputeRos2ForUnityPath);
     private static readonly Lazy<string> pluginPath = new Lazy<string>(ComputePluginPath);
     private static ConsoleCancelEventHandler consoleCancelHandler;
+    private const string Ros2csSpinFallbackEnvVar = "ROS2CS_SPIN_FALLBACK";
 
-    [DllImport("ucrtbase.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-    private static extern int _putenv_s(string name, string value);
+    [DllImport("ucrtbase.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+    private static extern int _wputenv_s(string name, string value);
 
 #if UNITY_EDITOR
     private static bool editorHandlersRegistered = false;
@@ -110,7 +111,14 @@ internal class ROS2ForUnity : IDisposable
         Environment.SetEnvironmentVariable(name, value);
         if (GetOS() == Platform.Windows)
         {
-            _putenv_s(name, value);
+            // ROS 2 Windows binaries use the dynamic UCRT, so update the CRT environment
+            // as well as the managed process environment for native getenv callers.
+            int result = _wputenv_s(name, value);
+            if (result != 0)
+            {
+                throw new InvalidOperationException(
+                    "Failed to set Windows CRT environment variable '" + name + "' (ucrtbase _wputenv_s returned " + result + ")");
+            }
         }
     }
 
@@ -259,6 +267,20 @@ internal class ROS2ForUnity : IDisposable
         if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("ROS_DISTRO")))
         {
             SetProcessEnvironmentVariable("ROS_DISTRO", ros2Codename);
+        }
+    }
+
+    private static void SetStandaloneRos2csSpinFallback(string ros2Codename)
+    {
+        if (!String.Equals(ros2Codename, "lyrical", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable(Ros2csSpinFallbackEnvVar)))
+        {
+            SetProcessEnvironmentVariable(Ros2csSpinFallbackEnvVar, "direct");
+            Debug.Log("ROS2CS spin fallback enabled for Lyrical standalone runtime.");
         }
     }
 
@@ -501,6 +523,7 @@ internal class ROS2ForUnity : IDisposable
                 if (IsStandalone())
                 {
                     SetStandaloneRosDistro(currentRos2Version);
+                    SetStandaloneRos2csSpinFallback(currentRos2Version);
                     SetStandalonePrefixPath();
                     SetStandaloneRmwImplementation();
                     SetStandaloneRcutilsConsoleMode();

--- a/src/Ros2ForUnity/Scripts/ROS2ListenerExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ListenerExample.cs
@@ -30,10 +30,19 @@ public class ROS2ListenerExample : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+        if (ros2Unity == null)
+        {
+            Debug.LogError("ROS2ListenerExample requires ROS2UnityComponent on the same GameObject.");
+        }
     }
 
     void Update()
     {
+        if (ros2Unity == null)
+        {
+            return;
+        }
+
         if (ros2Node == null && ros2Unity.Ok())
         {
             ros2Node = ros2Unity.CreateNode("ROS2UnityListenerNode");

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -29,7 +29,19 @@ public class ROS2Node : IDisposable
     internal INode node;
     public ROS2Clock clock;
     public string name;
+    private readonly object mutex = new object();
     private bool disposed;
+
+    internal bool IsDisposed
+    {
+        get
+        {
+            lock (mutex)
+            {
+                return disposed;
+            }
+        }
+    }
 
     // Use ROS2UnityComponent to create a node
     internal ROS2Node(string unityROS2NodeName = "unity_ros2_node")
@@ -41,16 +53,27 @@ public class ROS2Node : IDisposable
 
     public void Dispose()
     {
-        if (disposed)
+        INode nodeToDispose = null;
+        ROS2Clock clockToDispose = null;
+        lock (mutex)
         {
-            return;
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            nodeToDispose = node;
+            clockToDispose = clock;
+            node = null;
+            clock = null;
         }
 
         try
         {
-            if (node != null)
+            if (nodeToDispose != null)
             {
-                Ros2cs.RemoveNode(node);
+                Ros2cs.RemoveNode(nodeToDispose);
             }
         }
         catch (Exception e)
@@ -59,21 +82,44 @@ public class ROS2Node : IDisposable
         }
         finally
         {
-            node = null;
-            if (clock != null)
+            if (clockToDispose != null)
             {
-                clock.Dispose();
-                clock = null;
+                clockToDispose.Dispose();
             }
-            disposed = true;
+        }
+    }
+
+    internal bool TryUpdateROSTimestamp(ref MessageWithHeader message)
+    {
+        lock (mutex)
+        {
+            if (disposed || clock == null)
+            {
+                return false;
+            }
+
+            clock.UpdateROSTimestamp(ref message);
+            return true;
         }
     }
 
     private void ThrowIfUninitialized(string callContext)
     {
-        if (disposed || node == null || !Ros2cs.Ok())
+        lock (mutex)
         {
-            throw new InvalidOperationException("Ros2 For Unity is not initialized, can't " + callContext);
+            if (disposed || node == null || !Ros2cs.Ok())
+            {
+                throw new InvalidOperationException("Ros2 For Unity is not initialized, can't " + callContext);
+            }
+        }
+    }
+
+    private TResult WithLiveNode<TResult>(string callContext, Func<INode, TResult> action)
+    {
+        lock (mutex)
+        {
+            ThrowIfUninitialized(callContext);
+            return action(node);
         }
     }
 
@@ -98,8 +144,7 @@ public class ROS2Node : IDisposable
     /// <param name="qos">QoS for publishing. If no QoS is selected, it will default to reliable, keep 10 last</param>
     public Publisher<T> CreatePublisher<T>(string topicName, QualityOfServiceProfile qos = null) where T : Message, new()
     {
-        ThrowIfUninitialized("create publisher");
-        return node.CreatePublisher<T>(topicName, qos);
+        return WithLiveNode("create publisher", liveNode => liveNode.CreatePublisher<T>(topicName, qos));
     }
 
     /// <summary>
@@ -116,11 +161,10 @@ public class ROS2Node : IDisposable
             using (QualityOfServiceProfile defaultQos = new QualityOfServiceProfile(QosPresetProfile.DEFAULT))
             {
                 ThrowIfUninitialized("create subscription");
-                return node.CreateSubscription<T>(topicName, callback, defaultQos);
+                return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, defaultQos));
             }
         }
-        ThrowIfUninitialized("create subscription");
-        return node.CreateSubscription<T>(topicName, callback, qos);
+        return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, qos));
     }
 
 
@@ -131,8 +175,7 @@ public class ROS2Node : IDisposable
     /// <param name="subscription">subscrition to remove, returned from CreateSubscription</param>
     public bool RemoveSubscription<T>(ISubscriptionBase subscription)
     {
-        ThrowIfUninitialized("remove subscription");
-        return node.RemoveSubscription(subscription);
+        return WithLiveNode("remove subscription", liveNode => liveNode.RemoveSubscription(subscription));
     }
 
     /// <summary>
@@ -142,8 +185,7 @@ public class ROS2Node : IDisposable
     /// <param name="publisher">publisher to remove, returned from CreatePublisher or CreateSensorPublisher</param>
     public bool RemovePublisher<T>(IPublisherBase publisher)
     {
-        ThrowIfUninitialized("remove publisher");
-        return node.RemovePublisher(publisher);
+        return WithLiveNode("remove publisher", liveNode => liveNode.RemovePublisher(publisher));
     }
 
     /// <inheritdoc cref="INode.CreateService"/>
@@ -151,15 +193,13 @@ public class ROS2Node : IDisposable
         where I : Message, new()
         where O : Message, new()
     {
-        ThrowIfUninitialized("create service");
-        return node.CreateService<I, O>(topic, callback, qos);
+        return WithLiveNode("create service", liveNode => liveNode.CreateService<I, O>(topic, callback, qos));
     }
 
     /// <inheritdoc cref="INode.RemoveService"/>
     public bool RemoveService(IServiceBase service)
     {
-        ThrowIfUninitialized("remove service");
-        return node.RemoveService(service);
+        return WithLiveNode("remove service", liveNode => liveNode.RemoveService(service));
     }
 
     /// <inheritdoc cref="INode.CreateClient"/>
@@ -167,15 +207,13 @@ public class ROS2Node : IDisposable
         where I : Message, new()
         where O : Message, new()
     {
-        ThrowIfUninitialized(callContext: "create client");
-        return node.CreateClient<I, O>(topic, qos);
+        return WithLiveNode("create client", liveNode => liveNode.CreateClient<I, O>(topic, qos));
     }
 
     /// <inheritdoc cref="INode.RemoveClient"/>
     public bool RemoveClient(IClientBase client)
     {
-        ThrowIfUninitialized(callContext: "remove client");
-        return node.RemoveClient(client);
+        return WithLiveNode("remove client", liveNode => liveNode.RemoveClient(client));
     }
 }
 

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -163,14 +163,15 @@ public class ROS2Node : IDisposable
     public Subscription<T> CreateSubscription<T>(string topicName, Action<T> callback,
         QualityOfServiceProfile qos = null) where T : Message, new()
     {
-        if (qos == null)
+        if (qos != null)
         {
-            using (QualityOfServiceProfile defaultQos = new QualityOfServiceProfile(QosPresetProfile.DEFAULT))
-            {
-                return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, defaultQos));
-            }
+            return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, qos));
         }
-        return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, qos));
+
+        using (QualityOfServiceProfile defaultQos = new QualityOfServiceProfile(QosPresetProfile.DEFAULT))
+        {
+            return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, defaultQos));
+        }
     }
 
 
@@ -179,9 +180,14 @@ public class ROS2Node : IDisposable
     /// </summary>
     /// <returns>The whether subscription was found (e. g. false if removed earlier elsewhere) </returns>
     /// <param name="subscription">subscrition to remove, returned from CreateSubscription</param>
-    public bool RemoveSubscription<T>(ISubscriptionBase subscription)
+    public bool RemoveSubscription(ISubscriptionBase subscription)
     {
         return WithLiveNode("remove subscription", liveNode => liveNode.RemoveSubscription(subscription));
+    }
+
+    public bool RemoveSubscription<T>(ISubscriptionBase subscription)
+    {
+        return RemoveSubscription(subscription);
     }
 
     /// <summary>
@@ -189,9 +195,14 @@ public class ROS2Node : IDisposable
     /// </summary>
     /// <returns>The whether publisher was found (e. g. false if removed earlier elsewhere) </returns>
     /// <param name="publisher">publisher to remove, returned from CreatePublisher or CreateSensorPublisher</param>
-    public bool RemovePublisher<T>(IPublisherBase publisher)
+    public bool RemovePublisher(IPublisherBase publisher)
     {
         return WithLiveNode("remove publisher", liveNode => liveNode.RemovePublisher(publisher));
+    }
+
+    public bool RemovePublisher<T>(IPublisherBase publisher)
+    {
+        return RemovePublisher(publisher);
     }
 
     /// <inheritdoc cref="INode.CreateService"/>

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -105,8 +105,15 @@ public class ROS2Node : IDisposable
                 return false;
             }
 
-            clock.UpdateROSTimestamp(ref message);
-            return true;
+            try
+            {
+                clock.UpdateROSTimestamp(ref message);
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -27,8 +27,8 @@ namespace ROS2
 public class ROS2Node : IDisposable
 {
     internal INode node;
-    public ROS2Clock clock;
-    public string name;
+    public ROS2Clock clock { get; private set; }
+    public string name { get; }
     private readonly object mutex = new object();
     private bool disposed;
 
@@ -84,7 +84,14 @@ public class ROS2Node : IDisposable
         {
             if (clockToDispose != null)
             {
-                clockToDispose.Dispose();
+                try
+                {
+                    clockToDispose.Dispose();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
             }
         }
     }
@@ -160,7 +167,6 @@ public class ROS2Node : IDisposable
         {
             using (QualityOfServiceProfile defaultQos = new QualityOfServiceProfile(QosPresetProfile.DEFAULT))
             {
-                ThrowIfUninitialized("create subscription");
                 return WithLiveNode("create subscription", liveNode => liveNode.CreateSubscription<T>(topicName, callback, defaultQos));
             }
         }

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -71,7 +71,7 @@ public class ROS2Node : IDisposable
 
         try
         {
-            if (nodeToDispose != null)
+            if (nodeToDispose != null && Ros2cs.Ok())
             {
                 Ros2cs.RemoveNode(nodeToDispose);
             }
@@ -137,6 +137,7 @@ public class ROS2Node : IDisposable
     /// <param name="topicName">topic that will be used for publishing</param>
     public Publisher<T> CreateSensorPublisher<T>(string topicName) where T : Message, new()
     {
+        // ros2cs copies QoS settings during publisher creation; this temporary profile only configures that call.
         using (QualityOfServiceProfile sensorProfile = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA))
         {
             return CreatePublisher<T>(topicName, sensorProfile);

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -30,7 +30,7 @@ public class ROS2Node : IDisposable
     public ROS2Clock clock { get; private set; }
     public string name { get; }
     private readonly object mutex = new object();
-    private bool disposed;
+    private volatile bool disposed;
 
     internal bool IsDisposed
     {
@@ -98,6 +98,12 @@ public class ROS2Node : IDisposable
 
     internal bool TryUpdateROSTimestamp(ref MessageWithHeader message)
     {
+        if (disposed)
+        {
+            return false;
+        }
+
+        ROS2Clock clockToUse = null;
         lock (mutex)
         {
             if (disposed || clock == null)
@@ -105,15 +111,21 @@ public class ROS2Node : IDisposable
                 return false;
             }
 
-            try
-            {
-                clock.UpdateROSTimestamp(ref message);
-                return true;
-            }
-            catch (InvalidOperationException)
-            {
-                return false;
-            }
+            clockToUse = clock;
+        }
+
+        try
+        {
+            clockToUse.UpdateROSTimestamp(ref message);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -119,11 +119,11 @@ public class ROS2Node : IDisposable
             clockToUse.UpdateROSTimestamp(ref message);
             return true;
         }
-        catch (InvalidOperationException)
+        catch (ObjectDisposedException)
         {
             return false;
         }
-        catch (ObjectDisposedException)
+        catch (InvalidOperationException)
         {
             return false;
         }

--- a/src/Ros2ForUnity/Scripts/ROS2Node.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2Node.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +14,7 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor;
 
 namespace ROS2
 {
@@ -25,11 +24,12 @@ namespace ROS2
 /// but will also be removed properly with Ros2cs Shutdown, which ROS2 for Unity performs on application quit
 /// The node should be constructed through ROS2UnityComponent class, which also handles spinning
 /// </summary>
-public class ROS2Node
+public class ROS2Node : IDisposable
 {
     internal INode node;
     public ROS2Clock clock;
     public string name;
+    private bool disposed;
 
     // Use ROS2UnityComponent to create a node
     internal ROS2Node(string unityROS2NodeName = "unity_ros2_node")
@@ -39,14 +39,39 @@ public class ROS2Node
         clock = new ROS2Clock();
     }
 
-    ~ROS2Node()
+    public void Dispose()
     {
-        Ros2cs.RemoveNode(node);
+        if (disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            if (node != null)
+            {
+                Ros2cs.RemoveNode(node);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+        }
+        finally
+        {
+            node = null;
+            if (clock != null)
+            {
+                clock.Dispose();
+                clock = null;
+            }
+            disposed = true;
+        }
     }
 
-    private static void ThrowIfUninitialized(string callContext)
+    private void ThrowIfUninitialized(string callContext)
     {
-        if (!Ros2cs.Ok())
+        if (disposed || node == null || !Ros2cs.Ok())
         {
             throw new InvalidOperationException("Ros2 For Unity is not initialized, can't " + callContext);
         }
@@ -59,8 +84,10 @@ public class ROS2Node
     /// <param name="topicName">topic that will be used for publishing</param>
     public Publisher<T> CreateSensorPublisher<T>(string topicName) where T : Message, new()
     {
-        QualityOfServiceProfile sensorProfile = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA);
-        return CreatePublisher<T>(topicName, sensorProfile);
+        using (QualityOfServiceProfile sensorProfile = new QualityOfServiceProfile(QosPresetProfile.SENSOR_DATA))
+        {
+            return CreatePublisher<T>(topicName, sensorProfile);
+        }
     }
 
     /// <summary>
@@ -86,7 +113,11 @@ public class ROS2Node
     {
         if (qos == null)
         {
-            qos = new QualityOfServiceProfile(QosPresetProfile.DEFAULT);
+            using (QualityOfServiceProfile defaultQos = new QualityOfServiceProfile(QosPresetProfile.DEFAULT))
+            {
+                ThrowIfUninitialized("create subscription");
+                return node.CreateSubscription<T>(topicName, callback, defaultQos);
+            }
         }
         ThrowIfUninitialized("create subscription");
         return node.CreateSubscription<T>(topicName, callback, qos);

--- a/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
@@ -34,10 +34,17 @@ public class ROS2PerformanceTest : MonoBehaviour
     private bool initialized = false;
     private volatile bool quitting = false;
     private Thread publishThread;
+    private readonly object msgMutex = new object();
 
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+        if (ros2Unity == null)
+        {
+            Debug.LogError("ROS2PerformanceTest requires ROS2UnityComponent on the same GameObject.");
+            return;
+        }
+
         NormalizeInspectorValues();
         if (Application.isPlaying)
         {
@@ -48,6 +55,10 @@ public class ROS2PerformanceTest : MonoBehaviour
     void OnValidate()
     {
         NormalizeInspectorValues();
+        if (!Application.isPlaying)
+        {
+            return;
+        }
         PrepMessage();
     }
 
@@ -62,19 +73,26 @@ public class ROS2PerformanceTest : MonoBehaviour
     {
         while(!quitting)
         {
-            if (ros2Unity.Ok())
+            if (ros2Unity != null && ros2Unity.Ok())
             {
                 if (ros2Node == null)
                 {
                     ros2Node = ros2Unity.CreateNode("ros2_unity_performance_test_node");
                     perf_pub = ros2Node.CreateSensorPublisher<sensor_msgs.msg.PointCloud2>("perf_chatter");
                 }
-                if (msg == null)
+                sensor_msgs.msg.PointCloud2 messageToPublish;
+                lock (msgMutex)
                 {
-                    PrepMessage();
+                    messageToPublish = msg;
                 }
 
-                MessageWithHeader msgWithHeader = msg as MessageWithHeader;
+                if (messageToPublish == null)
+                {
+                    Thread.Sleep(100);
+                    continue;
+                }
+
+                MessageWithHeader msgWithHeader = messageToPublish as MessageWithHeader;
                 if (msgWithHeader == null)
                 {
                     Debug.LogError("PointCloud2 does not implement MessageWithHeader; cannot publish stamped performance message");
@@ -86,7 +104,7 @@ public class ROS2PerformanceTest : MonoBehaviour
                     Thread.Sleep(100);
                     continue;
                 }
-                perf_pub.Publish(msg);
+                perf_pub.Publish(messageToPublish);
                 if (interval_ms > 0)
                 {
                     Thread.Sleep(interval_ms);
@@ -101,6 +119,11 @@ public class ROS2PerformanceTest : MonoBehaviour
 
     void FixedUpdate()
     {
+        if (ros2Unity == null)
+        {
+            return;
+        }
+
         if (!initialized)
         {
             publishThread = new Thread(() => Publish());
@@ -130,11 +153,25 @@ public class ROS2PerformanceTest : MonoBehaviour
             catch (System.Exception e)
             {
                 Debug.LogException(e);
+                if (perf_pub != null)
+                {
+                    try
+                    {
+                        perf_pub.Dispose();
+                    }
+                    catch (System.Exception disposeException)
+                    {
+                        Debug.LogException(disposeException);
+                    }
+                }
             }
         }
         perf_pub = null;
         ros2Node = null;
-        msg = null;
+        lock (msgMutex)
+        {
+            msg = null;
+        }
     }
 
     private void AssignField(ref sensor_msgs.msg.PointField pf, string n, uint off, byte dt, uint count)
@@ -151,7 +188,7 @@ public class ROS2PerformanceTest : MonoBehaviour
         uint count = (uint)messageSize; //point per message
         uint fieldsSize = 16;
         uint rowSize = count * fieldsSize;
-        msg = new sensor_msgs.msg.PointCloud2()
+        sensor_msgs.msg.PointCloud2 newMsg = new sensor_msgs.msg.PointCloud2()
         {
             Height = 1,
             Width = count,
@@ -162,17 +199,17 @@ public class ROS2PerformanceTest : MonoBehaviour
             Data = new byte[rowSize * 1]
         };
         uint pointFieldCount = 4;
-        msg.Fields = new sensor_msgs.msg.PointField[pointFieldCount];
+        newMsg.Fields = new sensor_msgs.msg.PointField[pointFieldCount];
         for (int i = 0; i < pointFieldCount; ++i)
         {
-            msg.Fields[i] = new sensor_msgs.msg.PointField();
+            newMsg.Fields[i] = new sensor_msgs.msg.PointField();
         }
 
-        AssignField(ref msg.Fields[0], "x", 0, 7, 1);
-        AssignField(ref msg.Fields[1], "y", 4, 7, 1);
-        AssignField(ref msg.Fields[2], "z", 8, 7, 1);
-        AssignField(ref msg.Fields[3], "intensity", 12, 7, 1);
-        float[] pointsArray = new float[count * msg.Fields.Length];
+        AssignField(ref newMsg.Fields[0], "x", 0, 7, 1);
+        AssignField(ref newMsg.Fields[1], "y", 4, 7, 1);
+        AssignField(ref newMsg.Fields[2], "z", 8, 7, 1);
+        AssignField(ref newMsg.Fields[3], "intensity", 12, 7, 1);
+        float[] pointsArray = new float[count * newMsg.Fields.Length];
 
         var floatIndex = 0;
         for (int i = 0; i < count; ++i)
@@ -183,8 +220,12 @@ public class ROS2PerformanceTest : MonoBehaviour
             pointsArray[floatIndex++] = 3;
             pointsArray[floatIndex++] = intensity;
         }
-        System.Buffer.BlockCopy(pointsArray, 0, msg.Data, 0, msg.Data.Length);
-        msg.SetHeaderFrame("pc");
+        System.Buffer.BlockCopy(pointsArray, 0, newMsg.Data, 0, newMsg.Data.Length);
+        newMsg.SetHeaderFrame("pc");
+        lock (msgMutex)
+        {
+            msg = newMsg;
+        }
     }
 }
 

--- a/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
@@ -38,6 +38,7 @@ public class ROS2PerformanceTest : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+        NormalizeInspectorValues();
         if (Application.isPlaying)
         {
             PrepMessage();
@@ -46,15 +47,15 @@ public class ROS2PerformanceTest : MonoBehaviour
 
     void OnValidate()
     {
-        if (rate < 1)
-        {
-            interval_ms = 0;
-        }
-        else
-        {
-            interval_ms = 1000 / rate;
-        }
+        NormalizeInspectorValues();
         PrepMessage();
+    }
+
+    private void NormalizeInspectorValues()
+    {
+        messageSize = Mathf.Max(1, messageSize);
+        rate = Mathf.Max(1, rate);
+        interval_ms = Mathf.Max(1, 1000 / rate);
     }
 
     private void Publish()
@@ -114,7 +115,10 @@ public class ROS2PerformanceTest : MonoBehaviour
         quitting = true;
         if (publishThread != null && publishThread != Thread.CurrentThread)
         {
-            publishThread.Join(2000);
+            if (!publishThread.Join(2000))
+            {
+                Debug.LogWarning("ROS2PerformanceTest publish thread did not stop within 2 seconds");
+            }
             publishThread = null;
         }
         if (ros2Unity != null && ros2Node != null)
@@ -143,6 +147,7 @@ public class ROS2PerformanceTest : MonoBehaviour
 
     private void PrepMessage()
     {
+        NormalizeInspectorValues();
         uint count = (uint)messageSize; //point per message
         uint fieldsSize = 16;
         uint rowSize = count * fieldsSize;

--- a/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +32,8 @@ public class ROS2PerformanceTest : MonoBehaviour
     private IPublisher<sensor_msgs.msg.PointCloud2> perf_pub;
     sensor_msgs.msg.PointCloud2 msg;
     private bool initialized = false;
+    private volatile bool quitting = false;
+    private Thread publishThread;
 
     void Start()
     {
@@ -53,7 +56,7 @@ public class ROS2PerformanceTest : MonoBehaviour
 
     private void Publish()
     {
-        while(true)
+        while(!quitting)
         {
             if (ros2Unity.Ok())
             {
@@ -71,6 +74,10 @@ public class ROS2PerformanceTest : MonoBehaviour
                     Thread.Sleep(interval_ms);
                 }
             }
+            else
+            {
+                Thread.Sleep(100);
+            }
         }
     }
 
@@ -78,9 +85,20 @@ public class ROS2PerformanceTest : MonoBehaviour
     {
         if (!initialized)
         {
-            Thread publishThread = new Thread(() => Publish());
+            publishThread = new Thread(() => Publish());
+            publishThread.IsBackground = true;
             publishThread.Start();
             initialized = true;
+        }
+    }
+
+    void OnDestroy()
+    {
+        quitting = true;
+        if (publishThread != null && publishThread != Thread.CurrentThread)
+        {
+            publishThread.Join(2000);
+            publishThread = null;
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
@@ -31,10 +31,12 @@ public class ROS2PerformanceTest : MonoBehaviour
     private ROS2Node ros2Node;
     private IPublisher<sensor_msgs.msg.PointCloud2> perf_pub;
     private sensor_msgs.msg.PointCloud2 msg;
+    private MessageWithHeader msgWithHeader;
     private bool initialized = false;
     private volatile bool quitting = false;
     private Thread publishThread;
     private readonly object msgMutex = new object();
+    private static readonly byte[] pointDataPattern = CreatePointDataPattern();
 
     void Start()
     {
@@ -54,9 +56,9 @@ public class ROS2PerformanceTest : MonoBehaviour
 
     void OnValidate()
     {
-        NormalizeInspectorValues();
         if (!Application.isPlaying)
         {
+            NormalizeInspectorValues();
             return;
         }
         PrepMessage();
@@ -81,9 +83,11 @@ public class ROS2PerformanceTest : MonoBehaviour
                     perf_pub = ros2Node.CreateSensorPublisher<sensor_msgs.msg.PointCloud2>("perf_chatter");
                 }
                 sensor_msgs.msg.PointCloud2 messageToPublish;
+                MessageWithHeader headerToUpdate;
                 lock (msgMutex)
                 {
                     messageToPublish = msg;
+                    headerToUpdate = msgWithHeader;
                 }
 
                 if (messageToPublish == null)
@@ -92,14 +96,13 @@ public class ROS2PerformanceTest : MonoBehaviour
                     continue;
                 }
 
-                MessageWithHeader msgWithHeader = messageToPublish as MessageWithHeader;
-                if (msgWithHeader == null)
+                if (headerToUpdate == null)
                 {
                     Debug.LogError("PointCloud2 does not implement MessageWithHeader; cannot publish stamped performance message");
                     quitting = true;
                     continue;
                 }
-                if (!ros2Node.TryUpdateROSTimestamp(ref msgWithHeader))
+                if (!ros2Node.TryUpdateROSTimestamp(ref headerToUpdate))
                 {
                     Thread.Sleep(100);
                     continue;
@@ -171,6 +174,7 @@ public class ROS2PerformanceTest : MonoBehaviour
         lock (msgMutex)
         {
             msg = null;
+            msgWithHeader = null;
         }
     }
 
@@ -180,6 +184,14 @@ public class ROS2PerformanceTest : MonoBehaviour
         pf.Offset = off;
         pf.Datatype = dt;
         pf.Count = count;
+    }
+
+    private static byte[] CreatePointDataPattern()
+    {
+        float[] pointValues = { 1f, 2f, 3f, 100f };
+        byte[] pattern = new byte[sizeof(float) * 4];
+        System.Buffer.BlockCopy(pointValues, 0, pattern, 0, pattern.Length);
+        return pattern;
     }
 
     private void PrepMessage()
@@ -209,22 +221,16 @@ public class ROS2PerformanceTest : MonoBehaviour
         AssignField(ref newMsg.Fields[1], "y", 4, 7, 1);
         AssignField(ref newMsg.Fields[2], "z", 8, 7, 1);
         AssignField(ref newMsg.Fields[3], "intensity", 12, 7, 1);
-        float[] pointsArray = new float[count * newMsg.Fields.Length];
-
-        var floatIndex = 0;
-        for (int i = 0; i < count; ++i)
+        for (int offset = 0; offset < newMsg.Data.Length; offset += pointDataPattern.Length)
         {
-            float intensity = 100;
-            pointsArray[floatIndex++] = 1;
-            pointsArray[floatIndex++] = 2;
-            pointsArray[floatIndex++] = 3;
-            pointsArray[floatIndex++] = intensity;
+            System.Buffer.BlockCopy(pointDataPattern, 0, newMsg.Data, offset, pointDataPattern.Length);
         }
-        System.Buffer.BlockCopy(pointsArray, 0, newMsg.Data, 0, newMsg.Data.Length);
         newMsg.SetHeaderFrame("pc");
+        MessageWithHeader newMsgWithHeader = newMsg as MessageWithHeader;
         lock (msgMutex)
         {
             msg = newMsg;
+            msgWithHeader = newMsgWithHeader;
         }
     }
 }

--- a/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2PerformanceTest.cs
@@ -30,7 +30,7 @@ public class ROS2PerformanceTest : MonoBehaviour
     private ROS2UnityComponent ros2Unity;
     private ROS2Node ros2Node;
     private IPublisher<sensor_msgs.msg.PointCloud2> perf_pub;
-    sensor_msgs.msg.PointCloud2 msg;
+    private sensor_msgs.msg.PointCloud2 msg;
     private bool initialized = false;
     private volatile bool quitting = false;
     private Thread publishThread;
@@ -38,7 +38,10 @@ public class ROS2PerformanceTest : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
-        PrepMessage();
+        if (Application.isPlaying)
+        {
+            PrepMessage();
+        }
     }
 
     void OnValidate()
@@ -65,9 +68,23 @@ public class ROS2PerformanceTest : MonoBehaviour
                     ros2Node = ros2Unity.CreateNode("ros2_unity_performance_test_node");
                     perf_pub = ros2Node.CreateSensorPublisher<sensor_msgs.msg.PointCloud2>("perf_chatter");
                 }
+                if (msg == null)
+                {
+                    PrepMessage();
+                }
 
-                var msgWithHeader = msg as MessageWithHeader;
-                ros2Node.clock.UpdateROSTimestamp(ref msgWithHeader);
+                MessageWithHeader msgWithHeader = msg as MessageWithHeader;
+                if (msgWithHeader == null)
+                {
+                    Debug.LogError("PointCloud2 does not implement MessageWithHeader; cannot publish stamped performance message");
+                    quitting = true;
+                    continue;
+                }
+                if (!ros2Node.TryUpdateROSTimestamp(ref msgWithHeader))
+                {
+                    Thread.Sleep(100);
+                    continue;
+                }
                 perf_pub.Publish(msg);
                 if (interval_ms > 0)
                 {
@@ -100,6 +117,20 @@ public class ROS2PerformanceTest : MonoBehaviour
             publishThread.Join(2000);
             publishThread = null;
         }
+        if (ros2Unity != null && ros2Node != null)
+        {
+            try
+            {
+                ros2Unity.RemoveNode(ros2Node);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+        perf_pub = null;
+        ros2Node = null;
+        msg = null;
     }
 
     private void AssignField(ref sensor_msgs.msg.PointField pf, string n, uint off, byte dt, uint count)

--- a/src/Ros2ForUnity/Scripts/ROS2ServiceExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ServiceExample.cs
@@ -33,10 +33,19 @@ public class ROS2ServiceExample : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+        if (ros2Unity == null)
+        {
+            Debug.LogError("ROS2ServiceExample requires ROS2UnityComponent on the same GameObject.");
+        }
     }
 
     void Update()
     {
+        if (ros2Unity == null)
+        {
+            return;
+        }
+
         if (ros2Unity.Ok())
         {
             if (ros2Node == null)

--- a/src/Ros2ForUnity/Scripts/ROS2ServiceExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2ServiceExample.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +33,10 @@ public class ROS2ServiceExample : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+    }
+
+    void Update()
+    {
         if (ros2Unity.Ok())
         {
             if (ros2Node == null)

--- a/src/Ros2ForUnity/Scripts/ROS2ServiceExample.cs.meta
+++ b/src/Ros2ForUnity/Scripts/ROS2ServiceExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e4a0f8cecfd4e8a900b0ebde30adbc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/ROS2TalkerExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2TalkerExample.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@ public class ROS2TalkerExample : MonoBehaviour
     private ROS2UnityComponent ros2Unity;
     private ROS2Node ros2Node;
     private IPublisher<std_msgs.msg.String> chatter_pub;
+    private std_msgs.msg.String msg;
     private int i;
 
     void Start()
@@ -41,10 +43,11 @@ public class ROS2TalkerExample : MonoBehaviour
             {
                 ros2Node = ros2Unity.CreateNode("ROS2UnityTalkerNode");
                 chatter_pub = ros2Node.CreatePublisher<std_msgs.msg.String>("chatter");
+                msg = new std_msgs.msg.String();
             }
 
             i++;
-            std_msgs.msg.String msg = new std_msgs.msg.String();
+            // Example-only hot path: reuse the message wrapper to avoid per-frame native allocations.
             msg.Data = "Unity ROS2 sending: hello " + i;
             chatter_pub.Publish(msg);
         }

--- a/src/Ros2ForUnity/Scripts/ROS2TalkerExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2TalkerExample.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using UnityEngine;
+using System.Text;
 
 namespace ROS2
 {
@@ -28,6 +29,7 @@ public class ROS2TalkerExample : MonoBehaviour
     private ROS2Node ros2Node;
     private IPublisher<std_msgs.msg.String> chatter_pub;
     private std_msgs.msg.String msg;
+    private readonly StringBuilder msgBuilder = new StringBuilder();
     private int i;
 
     void Start()
@@ -57,7 +59,10 @@ public class ROS2TalkerExample : MonoBehaviour
 
             i++;
             // Example-only hot path: reuse the message wrapper to avoid per-frame native allocations.
-            msg.Data = "Unity ROS2 sending: hello " + i;
+            msgBuilder.Clear();
+            msgBuilder.Append("Unity ROS2 sending: hello ");
+            msgBuilder.Append(i);
+            msg.Data = msgBuilder.ToString();
             chatter_pub.Publish(msg);
         }
     }

--- a/src/Ros2ForUnity/Scripts/ROS2TalkerExample.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2TalkerExample.cs
@@ -33,10 +33,19 @@ public class ROS2TalkerExample : MonoBehaviour
     void Start()
     {
         ros2Unity = GetComponent<ROS2UnityComponent>();
+        if (ros2Unity == null)
+        {
+            Debug.LogError("ROS2TalkerExample requires ROS2UnityComponent on the same GameObject.");
+        }
     }
 
     void Update()
     {
+        if (ros2Unity == null)
+        {
+            return;
+        }
+
         if (ros2Unity.Ok())
         {
             if (ros2Node == null)

--- a/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
@@ -170,7 +170,7 @@ public class ROS2UnityComponent : MonoBehaviour
 
             lock (mutex)
             {
-                if (!quitting && ros2forUnity != null && nodes != null && ros2forUnity.Ok())
+                if (!quitting && !disposed && ros2forUnity != null && nodes != null && ros2forUnity.Ok())
                 {
                     actionsSnapshot = new List<Action>(executableActions);
                     nodesSnapshot = new List<INode>(ros2csNodes);
@@ -212,6 +212,7 @@ public class ROS2UnityComponent : MonoBehaviour
 
     void FixedUpdate()
     {
+        // Start on the first fixed-timestep update so executor spin timing follows Unity physics cadence.
         StartExecutor();
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +37,9 @@ public class ROS2UnityComponent : MonoBehaviour
     private List<INode> ros2csNodes; // For performance in spinning
     private List<Action> executableActions;
     private bool initialized = false;
-    private bool quitting = false;
+    private volatile bool quitting = false;
+    private bool disposed = false;
+    private Thread executorThread;
     private int interval = 2;  // Spinning / executor interval in ms
     private object mutex = new object();
     private double spinTimeout = 0.0001;
@@ -45,6 +48,8 @@ public class ROS2UnityComponent : MonoBehaviour
     {
         lock (mutex)
         {
+            if (disposed)
+                return false;
             if (ros2forUnity == null)
                 LazyConstruct();
             return (nodes != null && ros2forUnity.Ok());
@@ -54,7 +59,8 @@ public class ROS2UnityComponent : MonoBehaviour
     private void LazyConstruct()
     {
         lock (mutex)
-        {        
+        {
+            ThrowIfDisposed();
             if (ros2forUnity != null)
                 return;
 
@@ -76,6 +82,7 @@ public class ROS2UnityComponent : MonoBehaviour
 
         lock (mutex)
         {
+            ThrowIfDisposed();
             foreach (ROS2Node n in nodes)
             {  // Assumed to be a rare operation on rather small (<1k) list
                 if (n.name == name)
@@ -92,10 +99,34 @@ public class ROS2UnityComponent : MonoBehaviour
 
     public void RemoveNode(ROS2Node node)
     {
+        RemoveNode(node, true);
+    }
+
+    public void DetachNode(ROS2Node node)
+    {
+        RemoveNode(node, false);
+    }
+
+    public void RemoveNode(ROS2Node node, bool dispose)
+    {
+        if (node == null)
+        {
+            return;
+        }
+
+        bool removed = false;
         lock (mutex)
         {
-            ros2csNodes.Remove(node.node);
-            nodes.Remove(node); //Node will be later deleted if unused, by GC
+            if (nodes != null)
+            {
+                ros2csNodes.Remove(node.node);
+                removed = nodes.Remove(node);
+            }
+        }
+
+        if (dispose && removed)
+        {
+            node.Dispose();
         }
     }
 
@@ -110,7 +141,11 @@ public class ROS2UnityComponent : MonoBehaviour
 
         lock (mutex)
         {
-            executableActions.Add(executable);
+            ThrowIfDisposed();
+            if (!executableActions.Contains(executable))
+            {
+                executableActions.Add(executable);
+            }
         }
     }
 
@@ -118,7 +153,10 @@ public class ROS2UnityComponent : MonoBehaviour
     {
         lock (mutex)
         {
-            executableActions.Remove(executable);
+            if (executableActions != null)
+            {
+                executableActions.Remove(executable);
+            }
         }
     }
 
@@ -129,15 +167,45 @@ public class ROS2UnityComponent : MonoBehaviour
     {
         while (!quitting)
         {
-            if (Ok())
+            List<Action> actionsSnapshot = null;
+            List<INode> nodesSnapshot = null;
+
+            lock (mutex)
             {
-                lock (mutex)
+                if (!quitting && ros2forUnity != null && nodes != null && ros2forUnity.Ok())
                 {
-                    foreach (Action action in executableActions)
+                    actionsSnapshot = new List<Action>(executableActions);
+                    nodesSnapshot = new List<INode>(ros2csNodes);
+                }
+            }
+
+            if (actionsSnapshot != null)
+            {
+                foreach (Action action in actionsSnapshot)
+                {
+                    try
                     {
                         action();
                     }
-                    Ros2cs.SpinOnce(ros2csNodes, spinTimeout);
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
+                }
+
+                if (nodesSnapshot.Count > 0)
+                {
+                    try
+                    {
+                        Ros2cs.SpinOnce(nodesSnapshot, spinTimeout);
+                    }
+                    catch (Exception e)
+                    {
+                        if (!quitting)
+                        {
+                            Debug.LogException(e);
+                        }
+                    }
                 }
             }
             Thread.Sleep(interval);
@@ -146,18 +214,124 @@ public class ROS2UnityComponent : MonoBehaviour
 
     void FixedUpdate()
     {
-        if (!initialized)
+        StartExecutor();
+    }
+
+    private void StartExecutor()
+    {
+        lock (mutex)
         {
-            Thread publishThread = new Thread(() => Tick());
-            publishThread.Start();
+            if (initialized || disposed)
+            {
+                return;
+            }
+
+            quitting = false;
+            executorThread = new Thread(() => Tick());
+            executorThread.IsBackground = true;
             initialized = true;
+            executorThread.Start();
+        }
+    }
+
+    private void StopExecutor()
+    {
+        Thread threadToJoin = null;
+        lock (mutex)
+        {
+            quitting = true;
+            threadToJoin = executorThread;
+        }
+
+        if (threadToJoin != null && threadToJoin != Thread.CurrentThread)
+        {
+            if (!threadToJoin.Join(TimeSpan.FromSeconds(2)))
+            {
+                Debug.LogWarning("ROS2UnityComponent executor thread did not stop within 2 seconds");
+            }
+        }
+
+        lock (mutex)
+        {
+            executorThread = null;
+            initialized = false;
+        }
+    }
+
+    private void DisposeNodes()
+    {
+        List<ROS2Node> nodesToDispose = null;
+        lock (mutex)
+        {
+            if (nodes != null)
+            {
+                nodesToDispose = new List<ROS2Node>(nodes);
+                nodes.Clear();
+                ros2csNodes.Clear();
+            }
+        }
+
+        if (nodesToDispose == null)
+        {
+            return;
+        }
+
+        foreach (ROS2Node node in nodesToDispose)
+        {
+            try
+            {
+                node.Dispose();
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+    }
+
+    private void Shutdown()
+    {
+        StopExecutor();
+        DisposeNodes();
+
+        ROS2ForUnity instance = null;
+        lock (mutex)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            instance = ros2forUnity;
+            ros2forUnity = null;
+            executableActions = null;
+            nodes = null;
+            ros2csNodes = null;
+        }
+
+        if (instance != null)
+        {
+            instance.DestroyROS2ForUnity();
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (disposed)
+        {
+            throw new ObjectDisposedException(nameof(ROS2UnityComponent));
         }
     }
 
     void OnApplicationQuit()
     {
-        quitting = true;
-        ros2forUnity.DestroyROS2ForUnity();
+        Shutdown();
+    }
+
+    void OnDestroy()
+    {
+        Shutdown();
     }
 }
 

--- a/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
@@ -34,6 +34,11 @@ public class ROS2UnityComponent : MonoBehaviour
     private List<ROS2Node> nodes;
     private List<INode> ros2csNodes; // For performance in spinning
     private List<Action> executableActions;
+    private HashSet<Action> executableActionSet;
+    private readonly List<Action> actionsSnapshot = new List<Action>();
+    private readonly List<INode> nodesSnapshot = new List<INode>();
+    private int collectionVersion = 0;
+    private int snapshotVersion = -1;
     private bool initialized = false;
     private volatile bool quitting = false;
     private bool disposed = false;
@@ -66,6 +71,7 @@ public class ROS2UnityComponent : MonoBehaviour
             nodes = new List<ROS2Node>();
             ros2csNodes = new List<INode>();
             executableActions = new List<Action>();
+            executableActionSet = new HashSet<Action>();
         }
     }
 
@@ -91,6 +97,7 @@ public class ROS2UnityComponent : MonoBehaviour
             ROS2Node node = new ROS2Node(name);
             nodes.Add(node);
             ros2csNodes.Add(node.node);
+            collectionVersion++;
             return node;
         }
     }
@@ -117,8 +124,12 @@ public class ROS2UnityComponent : MonoBehaviour
         {
             if (nodes != null)
             {
-                ros2csNodes.Remove(node.node);
                 removed = nodes.Remove(node);
+                bool removedRos2csNode = ros2csNodes.Remove(node.node);
+                if (removed || removedRos2csNode)
+                {
+                    collectionVersion++;
+                }
             }
         }
 
@@ -140,9 +151,10 @@ public class ROS2UnityComponent : MonoBehaviour
         lock (mutex)
         {
             ThrowIfDisposed();
-            if (!executableActions.Contains(executable))
+            if (executableActionSet.Add(executable))
             {
                 executableActions.Add(executable);
+                collectionVersion++;
             }
         }
     }
@@ -153,7 +165,11 @@ public class ROS2UnityComponent : MonoBehaviour
         {
             if (executableActions != null)
             {
-                executableActions.Remove(executable);
+                if (executableActionSet.Remove(executable))
+                {
+                    executableActions.Remove(executable);
+                    collectionVersion++;
+                }
             }
         }
     }
@@ -165,19 +181,25 @@ public class ROS2UnityComponent : MonoBehaviour
     {
         while (!quitting)
         {
-            List<Action> actionsSnapshot = null;
-            List<INode> nodesSnapshot = null;
+            bool hasSnapshot = false;
 
             lock (mutex)
             {
                 if (!quitting && !disposed && ros2forUnity != null && nodes != null && ros2forUnity.Ok())
                 {
-                    actionsSnapshot = new List<Action>(executableActions);
-                    nodesSnapshot = new List<INode>(ros2csNodes);
+                    if (snapshotVersion != collectionVersion)
+                    {
+                        actionsSnapshot.Clear();
+                        actionsSnapshot.AddRange(executableActions);
+                        nodesSnapshot.Clear();
+                        nodesSnapshot.AddRange(ros2csNodes);
+                        snapshotVersion = collectionVersion;
+                    }
+                    hasSnapshot = true;
                 }
             }
 
-            if (actionsSnapshot != null)
+            if (hasSnapshot)
             {
                 foreach (Action action in actionsSnapshot)
                 {
@@ -269,6 +291,7 @@ public class ROS2UnityComponent : MonoBehaviour
                 nodesToDispose = new List<ROS2Node>(nodes);
                 nodes.Clear();
                 ros2csNodes.Clear();
+                collectionVersion++;
             }
         }
 
@@ -312,8 +335,11 @@ public class ROS2UnityComponent : MonoBehaviour
             instance = ros2forUnity;
             ros2forUnity = null;
             executableActions = null;
+            executableActionSet = null;
             nodes = null;
             ros2csNodes = null;
+            actionsSnapshot.Clear();
+            nodesSnapshot.Clear();
         }
 
         if (instance != null)

--- a/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
@@ -291,10 +291,6 @@ public class ROS2UnityComponent : MonoBehaviour
 
     private void Shutdown()
     {
-        StopExecutor();
-        DisposeNodes();
-
-        ROS2ForUnity instance = null;
         lock (mutex)
         {
             if (disposed)
@@ -302,7 +298,16 @@ public class ROS2UnityComponent : MonoBehaviour
                 return;
             }
 
+            // Mark shutdown as started before joining/disposing so OnDestroy and OnApplicationQuit cannot race.
             disposed = true;
+        }
+
+        StopExecutor();
+        DisposeNodes();
+
+        ROS2ForUnity instance = null;
+        lock (mutex)
+        {
             instance = ros2forUnity;
             ros2forUnity = null;
             executableActions = null;

--- a/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityComponent.cs
@@ -25,10 +25,8 @@ namespace ROS2
 /// <summary>
 /// The principal MonoBehaviour class for handling ros2 nodes and executables.
 /// Use this to create ros2 node, check ros2 status.
-/// Spins and executes actions (e. g. clock, sensor publish triggers) in a dedicated thread
-/// TODO: this is meant to be used as a one-of (a singleton). Enforce. However, things should work
-/// anyway with more than one since the underlying library can handle multiple init and shutdown calls,
-/// and does node name uniqueness check independently.
+/// Spins and executes actions (e. g. clock, sensor publish triggers) in a dedicated thread.
+/// Multiple component instances are expected to work because the underlying ROS2 layer reference-counts init/shutdown.
 /// </summary>
 public class ROS2UnityComponent : MonoBehaviour
 {
@@ -41,7 +39,7 @@ public class ROS2UnityComponent : MonoBehaviour
     private bool disposed = false;
     private Thread executorThread;
     private int interval = 2;  // Spinning / executor interval in ms
-    private object mutex = new object();
+    private readonly object mutex = new object();
     private double spinTimeout = 0.0001;
 
     public bool Ok()
@@ -219,6 +217,7 @@ public class ROS2UnityComponent : MonoBehaviour
 
     private void StartExecutor()
     {
+        Thread threadToStart = null;
         lock (mutex)
         {
             if (initialized || disposed)
@@ -230,8 +229,9 @@ public class ROS2UnityComponent : MonoBehaviour
             executorThread = new Thread(() => Tick());
             executorThread.IsBackground = true;
             initialized = true;
-            executorThread.Start();
+            threadToStart = executorThread;
         }
+        threadToStart.Start();
     }
 
     private void StopExecutor()

--- a/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,13 +30,15 @@ namespace ROS2
     /// anyway with more than one since the underlying library can handle multiple init and shutdown calls,
     /// and does node name uniqueness check independently.
     /// </summary>
-    public class ROS2UnityCore
+    public class ROS2UnityCore : IDisposable
     {
         private ROS2ForUnity ros2forUnity;
         private List<ROS2Node> nodes;
         private List<INode> ros2csNodes; // For performance in spinning
         private List<Action> executableActions;
-        private bool quitting = false;
+        private volatile bool quitting = false;
+        private bool disposed = false;
+        private Thread executorThread;
         private int interval = 2;  // Spinning / executor interval in ms
         private object mutex = new object();
         private double spinTimeout = 0.0001;
@@ -44,7 +47,7 @@ namespace ROS2
         {
             lock (mutex)
             {
-                return (nodes != null && ros2forUnity.Ok());
+                return (!disposed && nodes != null && ros2forUnity.Ok());
             }
         }
 
@@ -57,8 +60,9 @@ namespace ROS2
                 ros2csNodes = new List<INode>();
                 executableActions = new List<Action>();
 
-                Thread publishThread = new Thread(() => Tick());
-                publishThread.Start();
+                executorThread = new Thread(() => Tick());
+                executorThread.IsBackground = true;
+                executorThread.Start();
             }
         }
 
@@ -66,6 +70,7 @@ namespace ROS2
         {
             lock (mutex)
             {
+                ThrowIfDisposed();
                 foreach (ROS2Node n in nodes)
                 {  // Assumed to be a rare operation on rather small (<1k) list
                     if (n.name == name)
@@ -82,10 +87,34 @@ namespace ROS2
 
         public void RemoveNode(ROS2Node node)
         {
+            RemoveNode(node, true);
+        }
+
+        public void DetachNode(ROS2Node node)
+        {
+            RemoveNode(node, false);
+        }
+
+        public void RemoveNode(ROS2Node node, bool dispose)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            bool removed = false;
             lock (mutex)
             {
-                ros2csNodes.Remove(node.node);
-                nodes.Remove(node); //Node will be later deleted if unused, by GC
+                if (nodes != null)
+                {
+                    ros2csNodes.Remove(node.node);
+                    removed = nodes.Remove(node);
+                }
+            }
+
+            if (dispose && removed)
+            {
+                node.Dispose();
             }
         }
 
@@ -98,7 +127,11 @@ namespace ROS2
         {
             lock (mutex)
             {
-                executableActions.Add(executable);
+                ThrowIfDisposed();
+                if (!executableActions.Contains(executable))
+                {
+                    executableActions.Add(executable);
+                }
             }
         }
 
@@ -106,7 +139,10 @@ namespace ROS2
         {
             lock (mutex)
             {
-                executableActions.Remove(executable);
+                if (executableActions != null)
+                {
+                    executableActions.Remove(executable);
+                }
             }
         }
 
@@ -117,15 +153,45 @@ namespace ROS2
         {
             while (!quitting)
             {
-                if (Ok())
+                List<Action> actionsSnapshot = null;
+                List<INode> nodesSnapshot = null;
+
+                lock (mutex)
                 {
-                    lock (mutex)
+                    if (!quitting && !disposed && ros2forUnity != null && nodes != null && ros2forUnity.Ok())
                     {
-                        foreach (Action action in executableActions)
+                        actionsSnapshot = new List<Action>(executableActions);
+                        nodesSnapshot = new List<INode>(ros2csNodes);
+                    }
+                }
+
+                if (actionsSnapshot != null)
+                {
+                    foreach (Action action in actionsSnapshot)
+                    {
+                        try
                         {
                             action();
                         }
-                        Ros2cs.SpinOnce(ros2csNodes, spinTimeout);
+                        catch (Exception e)
+                        {
+                            Debug.LogException(e);
+                        }
+                    }
+
+                    if (nodesSnapshot.Count > 0)
+                    {
+                        try
+                        {
+                            Ros2cs.SpinOnce(nodesSnapshot, spinTimeout);
+                        }
+                        catch (Exception e)
+                        {
+                            if (!quitting)
+                            {
+                                Debug.LogException(e);
+                            }
+                        }
                     }
                 }
                 Thread.Sleep(interval);
@@ -134,8 +200,96 @@ namespace ROS2
 
         public void DestroyNow()
         {
-            quitting = true;
-            ros2forUnity.DestroyROS2ForUnity();
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            StopExecutor();
+            DisposeNodes();
+
+            ROS2ForUnity instance = null;
+            lock (mutex)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+                instance = ros2forUnity;
+                ros2forUnity = null;
+                executableActions = null;
+                nodes = null;
+                ros2csNodes = null;
+            }
+
+            if (instance != null)
+            {
+                instance.DestroyROS2ForUnity();
+            }
+        }
+
+        private void StopExecutor()
+        {
+            Thread threadToJoin = null;
+            lock (mutex)
+            {
+                quitting = true;
+                threadToJoin = executorThread;
+            }
+
+            if (threadToJoin != null && threadToJoin != Thread.CurrentThread)
+            {
+                if (!threadToJoin.Join(TimeSpan.FromSeconds(2)))
+                {
+                    Debug.LogWarning("ROS2UnityCore executor thread did not stop within 2 seconds");
+                }
+            }
+
+            lock (mutex)
+            {
+                executorThread = null;
+            }
+        }
+
+        private void DisposeNodes()
+        {
+            List<ROS2Node> nodesToDispose = null;
+            lock (mutex)
+            {
+                if (nodes != null)
+                {
+                    nodesToDispose = new List<ROS2Node>(nodes);
+                    nodes.Clear();
+                    ros2csNodes.Clear();
+                }
+            }
+
+            if (nodesToDispose == null)
+            {
+                return;
+            }
+
+            foreach (ROS2Node node in nodesToDispose)
+            {
+                try
+                {
+                    node.Dispose();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(ROS2UnityCore));
+            }
         }
     }
 

--- a/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
@@ -34,6 +34,11 @@ namespace ROS2
         private List<ROS2Node> nodes;
         private List<INode> ros2csNodes; // For performance in spinning
         private List<Action> executableActions;
+        private HashSet<Action> executableActionSet;
+        private readonly List<Action> actionsSnapshot = new List<Action>();
+        private readonly List<INode> nodesSnapshot = new List<INode>();
+        private int collectionVersion = 0;
+        private int snapshotVersion = -1;
         private volatile bool quitting = false;
         private bool disposed = false;
         private Thread executorThread;
@@ -58,6 +63,7 @@ namespace ROS2
                 nodes = new List<ROS2Node>();
                 ros2csNodes = new List<INode>();
                 executableActions = new List<Action>();
+                executableActionSet = new HashSet<Action>();
 
                 executorThread = new Thread(() => Tick());
                 executorThread.IsBackground = true;
@@ -81,6 +87,7 @@ namespace ROS2
                 ROS2Node node = new ROS2Node(name);
                 nodes.Add(node);
                 ros2csNodes.Add(node.node);
+                collectionVersion++;
                 return node;
             }
         }
@@ -107,8 +114,12 @@ namespace ROS2
             {
                 if (nodes != null)
                 {
-                    ros2csNodes.Remove(node.node);
                     removed = nodes.Remove(node);
+                    bool removedRos2csNode = ros2csNodes.Remove(node.node);
+                    if (removed || removedRos2csNode)
+                    {
+                        collectionVersion++;
+                    }
                 }
             }
 
@@ -128,9 +139,10 @@ namespace ROS2
             lock (mutex)
             {
                 ThrowIfDisposed();
-                if (!executableActions.Contains(executable))
+                if (executableActionSet.Add(executable))
                 {
                     executableActions.Add(executable);
+                    collectionVersion++;
                 }
             }
         }
@@ -141,7 +153,11 @@ namespace ROS2
             {
                 if (executableActions != null)
                 {
-                    executableActions.Remove(executable);
+                    if (executableActionSet.Remove(executable))
+                    {
+                        executableActions.Remove(executable);
+                        collectionVersion++;
+                    }
                 }
             }
         }
@@ -153,19 +169,25 @@ namespace ROS2
         {
             while (!quitting)
             {
-                List<Action> actionsSnapshot = null;
-                List<INode> nodesSnapshot = null;
+                bool hasSnapshot = false;
 
                 lock (mutex)
                 {
                     if (!quitting && !disposed && ros2forUnity != null && nodes != null && ros2forUnity.Ok())
                     {
-                        actionsSnapshot = new List<Action>(executableActions);
-                        nodesSnapshot = new List<INode>(ros2csNodes);
+                        if (snapshotVersion != collectionVersion)
+                        {
+                            actionsSnapshot.Clear();
+                            actionsSnapshot.AddRange(executableActions);
+                            nodesSnapshot.Clear();
+                            nodesSnapshot.AddRange(ros2csNodes);
+                            snapshotVersion = collectionVersion;
+                        }
+                        hasSnapshot = true;
                     }
                 }
 
-                if (actionsSnapshot != null)
+                if (hasSnapshot)
                 {
                     foreach (Action action in actionsSnapshot)
                     {
@@ -228,8 +250,11 @@ namespace ROS2
                 instance = ros2forUnity;
                 ros2forUnity = null;
                 executableActions = null;
+                executableActionSet = null;
                 nodes = null;
                 ros2csNodes = null;
+                actionsSnapshot.Clear();
+                nodesSnapshot.Clear();
             }
 
             if (instance != null)
@@ -271,6 +296,7 @@ namespace ROS2
                     nodesToDispose = new List<ROS2Node>(nodes);
                     nodes.Clear();
                     ros2csNodes.Clear();
+                    collectionVersion++;
                 }
             }
 

--- a/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
@@ -205,10 +205,6 @@ namespace ROS2
 
         public void Dispose()
         {
-            StopExecutor();
-            DisposeNodes();
-
-            ROS2ForUnity instance = null;
             lock (mutex)
             {
                 if (disposed)
@@ -216,7 +212,16 @@ namespace ROS2
                     return;
                 }
 
+                // Mark disposal as started before joining/disposing to make concurrent Dispose calls idempotent.
                 disposed = true;
+            }
+
+            StopExecutor();
+            DisposeNodes();
+
+            ROS2ForUnity instance = null;
+            lock (mutex)
+            {
                 instance = ros2forUnity;
                 ros2forUnity = null;
                 executableActions = null;

--- a/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
+++ b/src/Ros2ForUnity/Scripts/ROS2UnityCore.cs
@@ -25,10 +25,8 @@ namespace ROS2
     /// <summary>
     /// The principal class for handling ros2 nodes and executables.
     /// Use this to create ros2 node, check ros2 status.
-    /// Spins and executes actions (e. g. clock, sensor publish triggers) in a dedicated thread
-    /// TODO: this is meant to be used as a one-of (a singleton). Enforce. However, things should work
-    /// anyway with more than one since the underlying library can handle multiple init and shutdown calls,
-    /// and does node name uniqueness check independently.
+    /// Spins and executes actions (e. g. clock, sensor publish triggers) in a dedicated thread.
+    /// Multiple core instances are expected to work because the underlying ROS2 layer reference-counts init/shutdown.
     /// </summary>
     public class ROS2UnityCore : IDisposable
     {
@@ -40,7 +38,7 @@ namespace ROS2
         private bool disposed = false;
         private Thread executorThread;
         private int interval = 2;  // Spinning / executor interval in ms
-        private object mutex = new object();
+        private readonly object mutex = new object();
         private double spinTimeout = 0.0001;
 
         public bool Ok()
@@ -53,6 +51,7 @@ namespace ROS2
 
         public ROS2UnityCore()
         {
+            Thread threadToStart = null;
             lock (mutex)
             {
                 ros2forUnity = new ROS2ForUnity();
@@ -62,8 +61,9 @@ namespace ROS2
 
                 executorThread = new Thread(() => Tick());
                 executorThread.IsBackground = true;
-                executorThread.Start();
+                threadToStart = executorThread;
             }
+            threadToStart.Start();
         }
 
         public ROS2Node CreateNode(string name)
@@ -198,6 +198,9 @@ namespace ROS2
             }
         }
 
+        /// <summary>
+        /// Compatibility alias for older callers; new code should call Dispose().
+        /// </summary>
         public void DestroyNow()
         {
             Dispose();

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -76,9 +76,13 @@ public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, ne
 
     /// <summary>
     /// Returns true when there is a new data available from sensor.
+    /// Subclasses are responsible for applying desiredFrameTime if they want frequency gating.
     /// </summary>
     protected abstract bool HasNewData();
 
+    /// <summary>
+    /// Desired seconds between sensor readings. The base class calculates this value but does not gate HasNewData().
+    /// </summary>
     protected double desiredFrameTime = 0.0;
     private const double minimumFrequency = 0.001;
     private Publisher<T> publisher;
@@ -92,6 +96,10 @@ public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, ne
 
     public override string frameName()
     {
+        if (String.IsNullOrEmpty(ownerAgentName))
+        {
+            return frameID;
+        }
         return ownerAgentName + "/" + frameID;
     }
 

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -89,6 +89,7 @@ public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, ne
     private ROS2UnityComponent ros2UnityComponent;
     private ROS2Node ros2Node;
     private string ownerAgentName;
+    private string cachedFrameName;
 
     private T readings;
     private bool newReadings;
@@ -96,6 +97,11 @@ public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, ne
 
     public override string frameName()
     {
+        if (cachedFrameName != null)
+        {
+            return cachedFrameName;
+        }
+
         if (String.IsNullOrEmpty(ownerAgentName))
         {
             return frameID;
@@ -141,6 +147,7 @@ public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, ne
         }
 
         ownerAgentName = agentName;
+        cachedFrameName = String.IsNullOrEmpty(ownerAgentName) ? frameID : ownerAgentName + "/" + frameID;
         ros2UnityComponent = ros2Unity;
         ros2Node = node;
         string nsName = agentName.Replace(" ", "_");

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -148,24 +148,34 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
     internal void ExecutorThreadSensorPublishAction()
     {
         T readingToPublish = null;
+        Publisher<T> publisherToUse = null;
+        ROS2UnityComponent componentToUse = null;
+        ROS2Node nodeToUse = null;
 
         lock (readingsMutex)
         {
-            if (newReadings && publisher != null && publishing)
+            if (newReadings && publisher != null && publishing && ros2Node != null && !ros2Node.IsDisposed)
             {
                 readingToPublish = readings;
                 newReadings = false;
+                publisherToUse = publisher;
+                componentToUse = ros2UnityComponent;
+                nodeToUse = ros2Node;
             }
         }
 
-        if (readingToPublish == null || ros2UnityComponent == null || !ros2UnityComponent.Ok())
+        if (readingToPublish == null || componentToUse == null || nodeToUse == null || !componentToUse.Ok())
         {
             return;
         }
 
-        MessageWithHeader readingsHeader = readingToPublish as MessageWithHeader;
-        ros2Node.clock.UpdateROSTimestamp(ref readingsHeader);
-        publisher.Publish(readingToPublish);
+        MessageWithHeader readingsHeader = readingToPublish;
+        if (!nodeToUse.TryUpdateROSTimestamp(ref readingsHeader))
+        {
+            UnregisterExecutable();
+            return;
+        }
+        publisherToUse.Publish(readingToPublish);
     }
 
     /// <summary>
@@ -182,7 +192,8 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
 
     private void UpdateReadingOnMainThread()
     {
-        if (!publishing || publisher == null || ros2UnityComponent == null || !ros2UnityComponent.Ok())
+        if (!publishing || publisher == null || ros2Node == null || ros2Node.IsDisposed ||
+            ros2UnityComponent == null || !ros2UnityComponent.Ok())
         {
             return;
         }
@@ -217,23 +228,44 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
         CalculateFrameTime();
     }
 
-    protected virtual void OnDisable()
+    void OnDisable()
     {
         UnregisterExecutable();
+        OnSensorDisable();
     }
 
-    protected virtual void OnDestroy()
+    void OnDestroy()
     {
         UnregisterExecutable();
+        OnSensorDestroy();
+    }
+
+    protected virtual void OnSensorDisable()
+    {
+    }
+
+    protected virtual void OnSensorDestroy()
+    {
     }
 
     private void UnregisterExecutable()
     {
-        if (ros2UnityComponent != null)
+        ROS2UnityComponent componentToUnregister = null;
+        lock (readingsMutex)
         {
-            ros2UnityComponent.UnregisterExecutable(ExecutorThreadSensorPublishAction);
+            componentToUnregister = ros2UnityComponent;
             ros2UnityComponent = null;
+            ros2Node = null;
+            publisher = null;
+            readings = null;
+            newReadings = false;
         }
+
+        if (componentToUnregister != null)
+        {
+            componentToUnregister.UnregisterExecutable(ExecutorThreadSensorPublishAction);
+        }
+
         publishing = false;
     }
 

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -222,8 +222,8 @@ public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, ne
     /// </summary>
     void Awake()
     {
-        // turn on publishing on start
-        publishing = true;
+        // Publishing starts only after CreateROSParticipants creates a real ROS publisher.
+        publishing = false;
         CalculateFrameTime();
     }
 

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -142,8 +142,7 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
     }
 
     /// <summary>
-    /// This is executed in an executor thread (through RegisterExecutable).
-    /// Unity-facing acquisition happens in Update(); this method only publishes a cached reading.
+    /// Sensor sampling runs on Unity main thread in Update(); this executor-thread method only publishes a cached reading.
     /// </summary>
     internal void ExecutorThreadSensorPublishAction()
     {

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
 // limitations under the License.
 
 using UnityEngine;
-using UnityEngine.Profiling;
 using System;
 
 namespace ROS2
@@ -82,15 +82,13 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
     protected double desiredFrameTime = 0.0;
     private const double minimumFrequency = 0.001;
     private Publisher<T> publisher;
-    private Subscription<rosgraph_msgs.msg.Clock> clockSubscriber;
     private ROS2UnityComponent ros2UnityComponent;
     private ROS2Node ros2Node;
     private string ownerAgentName;
-    private double lastTimestamp;
-    private double timeSinceLastFixedUpdate;
 
     private T readings;
     private bool newReadings;
+    private readonly object readingsMutex = new object();
 
     public override string frameName()
     {
@@ -144,29 +142,30 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
     }
 
     /// <summary>
-    /// This is executed in an executor thread (through RegisterExecutable)
-    /// Sensor fequency is indirectly handed through newReadings, which are acquired at a requested
-    /// frequency if possible (e. g. due to simulation resource constraints)
+    /// This is executed in an executor thread (through RegisterExecutable).
+    /// Unity-facing acquisition happens in Update(); this method only publishes a cached reading.
     /// </summary>
     internal void ExecutorThreadSensorPublishAction()
     {
-        if (!HasNewData())
-            return;
+        T readingToPublish = null;
 
-        if (publisher != null & publishing)
+        lock (readingsMutex)
         {
-            if (ros2UnityComponent.Ok())
+            if (newReadings && publisher != null && publishing)
             {
-                readings = AcquireValue();
-                readings.SetHeaderFrame(frameName());
-                if (readings != null)
-                {
-                    MessageWithHeader readingsHeader = readings as MessageWithHeader;
-                    ros2Node.clock.UpdateROSTimestamp(ref readingsHeader);
-                    publisher.Publish(readings);
-                }
+                readingToPublish = readings;
+                newReadings = false;
             }
         }
+
+        if (readingToPublish == null || ros2UnityComponent == null || !ros2UnityComponent.Ok())
+        {
+            return;
+        }
+
+        MessageWithHeader readingsHeader = readingToPublish as MessageWithHeader;
+        ros2Node.clock.UpdateROSTimestamp(ref readingsHeader);
+        publisher.Publish(readingToPublish);
     }
 
     /// <summary>
@@ -178,6 +177,34 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
     {
         VisualiseEffects();
         OnUpdate();
+        UpdateReadingOnMainThread();
+    }
+
+    private void UpdateReadingOnMainThread()
+    {
+        if (!publishing || publisher == null || ros2UnityComponent == null || !ros2UnityComponent.Ok())
+        {
+            return;
+        }
+
+        // HasNewData() and AcquireValue() may call Unity APIs; keep them on the Unity main thread.
+        if (!HasNewData())
+        {
+            return;
+        }
+
+        T acquiredReading = AcquireValue();
+        if (acquiredReading == null)
+        {
+            return;
+        }
+
+        acquiredReading.SetHeaderFrame(frameName());
+        lock (readingsMutex)
+        {
+            readings = acquiredReading;
+            newReadings = true;
+        }
     }
 
     /// <summary>
@@ -188,7 +215,26 @@ public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
         // turn on publishing on start
         publishing = true;
         CalculateFrameTime();
-        lastTimestamp = DateTime.UtcNow.Ticks / 1E7;
+    }
+
+    protected virtual void OnDisable()
+    {
+        UnregisterExecutable();
+    }
+
+    protected virtual void OnDestroy()
+    {
+        UnregisterExecutable();
+    }
+
+    private void UnregisterExecutable()
+    {
+        if (ros2UnityComponent != null)
+        {
+            ros2UnityComponent.UnregisterExecutable(ExecutorThreadSensorPublishAction);
+            ros2UnityComponent = null;
+        }
+        publishing = false;
     }
 
     /// <summary>

--- a/src/Ros2ForUnity/Scripts/Sensor.cs
+++ b/src/Ros2ForUnity/Scripts/Sensor.cs
@@ -64,7 +64,7 @@ public abstract class ISensor : MonoBehaviour
 /// <summary>
 /// A base template class for the sensor. The type is the message type of sensor data.
 /// </summary>
-public abstract class Sensor<T> : ISensor where T : MessageWithHeader, new()
+public abstract class Sensor<T> : ISensor where T : class, MessageWithHeader, new()
 {
     /// <summary>
     /// Acquires the value by performing sensor type characteristic computations (e.g. raycasts).

--- a/src/Ros2ForUnity/Scripts/Time.meta
+++ b/src/Ros2ForUnity/Scripts/Time.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d980f37d88d94a04b770bb63a592bed1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
@@ -55,7 +55,7 @@ public class DotnetTimeSource : ITimeSource
     {
         lock(mutex) // Threading
         {
-            var durationInSeconds = stopwatch.Elapsed.TotalSeconds;
+            var durationInSeconds = stopwatch.ElapsedTicks / (double)Stopwatch.Frequency;
             double timeOffset = 0;
             if (durationInSeconds >= maxUnsyncedSeconds)
             {   // acquire DateTime to sync

--- a/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
@@ -1,4 +1,5 @@
 // Copyright 2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +25,8 @@ namespace ROS2
 /// </summary>
 public class DotnetTimeSource : ITimeSource
 {
+    private static readonly DateTime UnixEpoch =
+        new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private readonly double maxUnsyncedSeconds = 10;
 
     private Stopwatch stopwatch = new Stopwatch();
@@ -36,13 +39,14 @@ public class DotnetTimeSource : ITimeSource
 
     private double TotalSystemTimeSeconds()
     {
-        return TimeSpan.FromTicks(DateTime.UtcNow.Ticks).TotalSeconds;
+        return (DateTime.UtcNow - UnixEpoch).TotalSeconds;
     }
 
     private void UpdateSystemTime()
     {
         systemTimeIntervalStart = TotalSystemTimeSeconds();
-        stopwatchStartTimeStamp = Stopwatch.GetTimestamp();
+        stopwatch.Restart();
+        stopwatchStartTimeStamp = 0;
     }
 
     public DotnetTimeSource()
@@ -54,7 +58,7 @@ public class DotnetTimeSource : ITimeSource
     {
         lock(mutex) // Threading
         {
-            double endTimestamp = Stopwatch.GetTimestamp();
+            double endTimestamp = stopwatch.Elapsed.TotalSeconds;
             var durationInSeconds = endTimestamp - stopwatchStartTimeStamp;
             double timeOffset = 0;
             if (durationInSeconds >= maxUnsyncedSeconds)

--- a/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
@@ -35,8 +35,6 @@ public class DotnetTimeSource : ITimeSource
 
     private double systemTimeIntervalStart = 0;
 
-    private double stopwatchStartTimeStamp;
-
     private double TotalSystemTimeSeconds()
     {
         return (DateTime.UtcNow - UnixEpoch).TotalSeconds;
@@ -46,7 +44,6 @@ public class DotnetTimeSource : ITimeSource
     {
         systemTimeIntervalStart = TotalSystemTimeSeconds();
         stopwatch.Restart();
-        stopwatchStartTimeStamp = 0;
     }
 
     public DotnetTimeSource()
@@ -58,8 +55,7 @@ public class DotnetTimeSource : ITimeSource
     {
         lock(mutex) // Threading
         {
-            double endTimestamp = stopwatch.Elapsed.TotalSeconds;
-            var durationInSeconds = endTimestamp - stopwatchStartTimeStamp;
+            var durationInSeconds = stopwatch.Elapsed.TotalSeconds;
             double timeOffset = 0;
             if (durationInSeconds >= maxUnsyncedSeconds)
             {   // acquire DateTime to sync

--- a/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs
@@ -51,7 +51,7 @@ public class DotnetTimeSource : ITimeSource
         UpdateSystemTime();
     }
 
-    public void GetTime(out int seconds, out uint nanoseconds)
+    public bool GetTime(out int seconds, out uint nanoseconds)
     {
         lock(mutex) // Threading
         {
@@ -68,6 +68,7 @@ public class DotnetTimeSource : ITimeSource
             
             TimeUtils.TimeFromTotalSeconds(systemTimeIntervalStart + timeOffset, out seconds, out nanoseconds);
         }
+        return true;
     }
 }
 

--- a/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs.meta
+++ b/src/Ros2ForUnity/Scripts/Time/DotnetTimeSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 994af4b019af4560839b7dc216c57299
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs
@@ -1,4 +1,5 @@
 // Copyright 2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ namespace ROS2
 /// </summary>
 public interface ITimeSource
 {
-  public void GetTime(out int seconds, out uint nanoseconds);
+  void GetTime(out int seconds, out uint nanoseconds);
 }
 
 }  // namespace ROS2

--- a/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs
@@ -21,7 +21,8 @@ namespace ROS2
 /// </summary>
 public interface ITimeSource
 {
-  void GetTime(out int seconds, out uint nanoseconds);
+  /// <returns>True when a valid timestamp was acquired; false when the source is not currently usable.</returns>
+  bool GetTime(out int seconds, out uint nanoseconds);
 }
 
 }  // namespace ROS2

--- a/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs
@@ -17,7 +17,7 @@ namespace ROS2
 {
 
 /// <summary>
-/// Interace for acquiring time
+/// Interface for acquiring time.
 /// </summary>
 public interface ITimeSource
 {

--- a/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs.meta
+++ b/src/Ros2ForUnity/Scripts/Time/ITimeSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b275e0ab87b4c4f95153823e09bbb72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Time/ROS2Clock.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2Clock.cs
@@ -25,6 +25,7 @@ namespace ROS2
 public class ROS2Clock : IDisposable
 {
     private ITimeSource _timeSource;
+    private bool disposed;
 
     public ROS2Clock() : this(new ROS2TimeSource())
     {   // By default, use ROS2TimeSource
@@ -39,7 +40,7 @@ public class ROS2Clock : IDisposable
     {
         int seconds;
         uint nanoseconds;
-        _timeSource.GetTime(out seconds, out nanoseconds);
+        GetCurrentTime(out seconds, out nanoseconds);
         clockMessage.Clock_.Sec = seconds;
         clockMessage.Clock_.Nanosec = nanoseconds;
     }
@@ -48,7 +49,7 @@ public class ROS2Clock : IDisposable
     {
         int seconds;
         uint nanoseconds;
-        _timeSource.GetTime(out seconds, out nanoseconds);
+        GetCurrentTime(out seconds, out nanoseconds);
         time.Sec = seconds;
         time.Nanosec = nanoseconds;
     }
@@ -57,18 +58,33 @@ public class ROS2Clock : IDisposable
     {
         int seconds;
         uint nanoseconds;
-        _timeSource.GetTime(out seconds, out nanoseconds);
+        GetCurrentTime(out seconds, out nanoseconds);
         message.UpdateHeaderTime(seconds, nanoseconds);
+    }
+
+    private void GetCurrentTime(out int seconds, out uint nanoseconds)
+    {
+        if (disposed || _timeSource == null)
+        {
+            throw new ObjectDisposedException(nameof(ROS2Clock));
+        }
+        _timeSource.GetTime(out seconds, out nanoseconds);
     }
 
     public void Dispose()
     {
+        if (disposed)
+        {
+            return;
+        }
+
         IDisposable disposableTimeSource = _timeSource as IDisposable;
         if (disposableTimeSource != null)
         {
             disposableTimeSource.Dispose();
         }
         _timeSource = null;
+        disposed = true;
     }
 }
 

--- a/src/Ros2ForUnity/Scripts/Time/ROS2Clock.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2Clock.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +22,7 @@ namespace ROS2
 /// <summary>
 /// A ros2 clock class that for interfacing between a time source (unity or ros2 system time) and ros2cs messages, structs. 
 /// </summary>
-public class ROS2Clock
+public class ROS2Clock : IDisposable
 {
     private ITimeSource _timeSource;
 
@@ -58,6 +59,16 @@ public class ROS2Clock
         uint nanoseconds;
         _timeSource.GetTime(out seconds, out nanoseconds);
         message.UpdateHeaderTime(seconds, nanoseconds);
+    }
+
+    public void Dispose()
+    {
+        IDisposable disposableTimeSource = _timeSource as IDisposable;
+        if (disposableTimeSource != null)
+        {
+            disposableTimeSource.Dispose();
+        }
+        _timeSource = null;
     }
 }
 

--- a/src/Ros2ForUnity/Scripts/Time/ROS2Clock.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2Clock.cs
@@ -68,7 +68,10 @@ public class ROS2Clock : IDisposable
         {
             throw new ObjectDisposedException(nameof(ROS2Clock));
         }
-        _timeSource.GetTime(out seconds, out nanoseconds);
+        if (!_timeSource.GetTime(out seconds, out nanoseconds))
+        {
+            throw new InvalidOperationException("Cannot acquire valid ROS2 time from the configured time source.");
+        }
     }
 
     public void Dispose()

--- a/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
@@ -30,9 +30,9 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
   private int mainThreadId;
   private double lastReadingSecs;
   private ROS2.Clock clock;
-  private double initialTime = 0;
+  private double rosUnityTimeOffset = 0;
   private double initialTimeScale = 0;
-  private bool initialTimeAcquired = false;
+  private bool rosUnityTimeOffsetAcquired = false;
   private bool initialTimeScaleAcquired = false;
   private bool timeScaleChanged = false;
 
@@ -79,12 +79,12 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
       double adjustedTime;
       lock (mutex)
       {
-        if (!initialTimeAcquired)
+        if (!rosUnityTimeOffsetAcquired)
         {
-          initialTimeAcquired = true;
-          initialTime = rosNow - readingSecs;
+          rosUnityTimeOffsetAcquired = true;
+          rosUnityTimeOffset = rosNow - readingSecs;
         }
-        adjustedTime = readingSecs + initialTime;
+        adjustedTime = readingSecs + rosUnityTimeOffset;
       }
       TimeUtils.TimeFromTotalSeconds(adjustedTime, out seconds, out nanoseconds);
     }
@@ -114,6 +114,7 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
 
       if (initialTimeScale != Time.timeScale)
       {
+        // Once scaling has changed, keep using the adjusted timeline to avoid jumping back to system time.
         timeScaleChanged = true;
       }
 

--- a/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
@@ -61,11 +61,13 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
     double readingSecs;
     double scaleAtRead;
     bool scaleChangedAtRead;
+    bool offsetAcquiredAtRead;
     lock (mutex)
     {
       readingSecs = lastReadingSecs;
       scaleAtRead = initialTimeScale;
       scaleChangedAtRead = timeScaleChanged;
+      offsetAcquiredAtRead = rosUnityTimeOffsetAcquired;
     }
 
     if (scaleAtRead == 1.0 && !scaleChangedAtRead)
@@ -75,7 +77,7 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
     }
     else
     {
-      double rosNow = GetRosNowSeconds();
+      double rosNow = offsetAcquiredAtRead ? 0.0 : GetRosNowSeconds();
       double adjustedTime;
       lock (mutex)
       {

--- a/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
@@ -42,14 +42,14 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
     UpdateUnityTimeSnapshot();
   }
 
-  public void GetTime(out int seconds, out uint nanoseconds)
+  public bool GetTime(out int seconds, out uint nanoseconds)
   {
     if (!ROS2.Ros2cs.Ok())
     {
       seconds = 0;
       nanoseconds = 0;
       Debug.LogWarning("Cannot acquire valid ros time, ros either not initialized or shut down already");
-      return;
+      return false;
     }
 
     bool isMainThread = mainThreadId == Thread.CurrentThread.ManagedThreadId;
@@ -88,6 +88,7 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
       }
       TimeUtils.TimeFromTotalSeconds(adjustedTime, out seconds, out nanoseconds);
     }
+    return true;
   }
 
   private double GetRosNowSeconds()

--- a/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
@@ -26,6 +26,7 @@ namespace ROS2
 public class ROS2ScalableTimeSource : ITimeSource, IDisposable
 {
   private readonly object mutex = new object();
+  private readonly object clockMutex = new object();
   private int mainThreadId;
   private double lastReadingSecs;
   private ROS2.Clock clock;
@@ -51,11 +52,6 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
       return;
     }
 
-    if (clock == null)
-    { // Create clock which uses system time by default (unless use_sim_time is set in ros2)
-      clock = new ROS2.Clock();
-    }
-
     bool isMainThread = mainThreadId == Thread.CurrentThread.ManagedThreadId;
     if (isMainThread)
     {
@@ -74,11 +70,12 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
 
     if (scaleAtRead == 1.0 && !scaleChangedAtRead)
     {
-      TimeUtils.TimeFromTotalSeconds(clock.Now.Seconds, out seconds, out nanoseconds);
+      // Until Unity timeScale changes, preserve the default ROS/system clock behavior.
+      TimeUtils.TimeFromTotalSeconds(GetRosNowSeconds(), out seconds, out nanoseconds);
     }
     else
     {
-      double rosNow = clock.Now.Seconds;
+      double rosNow = GetRosNowSeconds();
       double adjustedTime;
       lock (mutex)
       {
@@ -90,6 +87,18 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
         adjustedTime = readingSecs + initialTime;
       }
       TimeUtils.TimeFromTotalSeconds(adjustedTime, out seconds, out nanoseconds);
+    }
+  }
+
+  private double GetRosNowSeconds()
+  {
+    lock (clockMutex)
+    {
+      if (clock == null)
+      { // Create clock which uses system time by default (unless use_sim_time is set in ros2)
+        clock = new ROS2.Clock();
+      }
+      return clock.Now.Seconds;
     }
   }
 
@@ -114,10 +123,13 @@ public class ROS2ScalableTimeSource : ITimeSource, IDisposable
 
   public void Dispose()
   {
-    if (clock != null)
+    lock (clockMutex)
     {
-      clock.Dispose();
-      clock = null;
+      if (clock != null)
+      {
+        clock.Dispose();
+        clock = null;
+      }
     }
   }
 }

--- a/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs
@@ -1,4 +1,5 @@
 // Copyright 2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Threading;
 using UnityEngine;
 
@@ -21,9 +23,10 @@ namespace ROS2
 /// <summary>
 /// ros2 time source (system time by default).
 /// </summary>
-public class ROS2ScalableTimeSource : ITimeSource
+public class ROS2ScalableTimeSource : ITimeSource, IDisposable
 {
-  private Thread mainThread;
+  private readonly object mutex = new object();
+  private int mainThreadId;
   private double lastReadingSecs;
   private ROS2.Clock clock;
   private double initialTime = 0;
@@ -34,7 +37,8 @@ public class ROS2ScalableTimeSource : ITimeSource
 
   public ROS2ScalableTimeSource()
   {
-    mainThread = Thread.CurrentThread;
+    mainThreadId = Thread.CurrentThread.ManagedThreadId;
+    UpdateUnityTimeSnapshot();
   }
 
   public void GetTime(out int seconds, out uint nanoseconds)
@@ -52,39 +56,68 @@ public class ROS2ScalableTimeSource : ITimeSource
       clock = new ROS2.Clock();
     }
 
-    if (!initialTimeScaleAcquired)
+    bool isMainThread = mainThreadId == Thread.CurrentThread.ManagedThreadId;
+    if (isMainThread)
     {
-      initialTimeScaleAcquired = true;
-      initialTimeScale = Time.timeScale;
+      UpdateUnityTimeSnapshot();
     }
 
-    if (initialTimeScale != Time.timeScale)
+    double readingSecs;
+    double scaleAtRead;
+    bool scaleChangedAtRead;
+    lock (mutex)
     {
-      timeScaleChanged = true;
+      readingSecs = lastReadingSecs;
+      scaleAtRead = initialTimeScale;
+      scaleChangedAtRead = timeScaleChanged;
     }
 
-    lastReadingSecs = mainThread.Equals(Thread.CurrentThread) ? Time.timeAsDouble : lastReadingSecs;
-
-    if (initialTimeScale == 1.0 && !timeScaleChanged)
+    if (scaleAtRead == 1.0 && !scaleChangedAtRead)
     {
       TimeUtils.TimeFromTotalSeconds(clock.Now.Seconds, out seconds, out nanoseconds);
     }
     else
     {
-      if (!initialTimeAcquired)
+      double rosNow = clock.Now.Seconds;
+      double adjustedTime;
+      lock (mutex)
       {
-        initialTimeAcquired = true;
-        initialTime = clock.Now.Seconds - Time.timeAsDouble;
+        if (!initialTimeAcquired)
+        {
+          initialTimeAcquired = true;
+          initialTime = rosNow - readingSecs;
+        }
+        adjustedTime = readingSecs + initialTime;
       }
-      TimeUtils.TimeFromTotalSeconds(lastReadingSecs + initialTime, out seconds, out nanoseconds);
+      TimeUtils.TimeFromTotalSeconds(adjustedTime, out seconds, out nanoseconds);
     }
   }
 
-  ~ROS2ScalableTimeSource()
+  private void UpdateUnityTimeSnapshot()
+  {
+    lock (mutex)
+    {
+      if (!initialTimeScaleAcquired)
+      {
+        initialTimeScaleAcquired = true;
+        initialTimeScale = Time.timeScale;
+      }
+
+      if (initialTimeScale != Time.timeScale)
+      {
+        timeScaleChanged = true;
+      }
+
+      lastReadingSecs = Time.timeAsDouble;
+    }
+  }
+
+  public void Dispose()
   {
     if (clock != null)
     {
       clock.Dispose();
+      clock = null;
     }
   }
 }

--- a/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs.meta
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2ScalableTimeSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb7b77f067114768848ea797a7001bee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs
@@ -27,14 +27,14 @@ public class ROS2TimeSource : ITimeSource, IDisposable
   private readonly object clockMutex = new object();
   private ROS2.Clock clock;
 
-  public void GetTime(out int seconds, out uint nanoseconds)
+  public bool GetTime(out int seconds, out uint nanoseconds)
   {
     if (!ROS2.Ros2cs.Ok())
     {
       seconds = 0;
       nanoseconds = 0;
       Debug.LogWarning("Cannot acquire valid ros time, ros either not initialized or shut down already");
-      return;
+      return false;
     }
 
     double nowSeconds;
@@ -48,6 +48,7 @@ public class ROS2TimeSource : ITimeSource, IDisposable
     }
 
     TimeUtils.TimeFromTotalSeconds(nowSeconds, out seconds, out nanoseconds);
+    return true;
   }
 
   public void Dispose()

--- a/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs
@@ -1,4 +1,5 @@
 // Copyright 2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using UnityEngine;
 
 namespace ROS2
@@ -20,7 +22,7 @@ namespace ROS2
 /// <summary>
 /// ros2 time source (system time by default).
 /// </summary>
-public class ROS2TimeSource : ITimeSource
+public class ROS2TimeSource : ITimeSource, IDisposable
 {
   private ROS2.Clock clock;
 
@@ -42,11 +44,12 @@ public class ROS2TimeSource : ITimeSource
     TimeUtils.TimeFromTotalSeconds(clock.Now.Seconds, out seconds, out nanoseconds);
   }
 
-  ~ROS2TimeSource()
+  public void Dispose()
   {
     if (clock != null)
     {
       clock.Dispose();
+      clock = null;
     }
   }
 }

--- a/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs
@@ -24,6 +24,7 @@ namespace ROS2
 /// </summary>
 public class ROS2TimeSource : ITimeSource, IDisposable
 {
+  private readonly object clockMutex = new object();
   private ROS2.Clock clock;
 
   public void GetTime(out int seconds, out uint nanoseconds)
@@ -36,20 +37,28 @@ public class ROS2TimeSource : ITimeSource, IDisposable
       return;
     }
 
-    if (clock == null)
-    { // Create clock which uses system time by default (unless use_sim_time is set in ros2)
-      clock = new ROS2.Clock();
+    double nowSeconds;
+    lock (clockMutex)
+    {
+      if (clock == null)
+      { // Create clock which uses system time by default (unless use_sim_time is set in ros2)
+        clock = new ROS2.Clock();
+      }
+      nowSeconds = clock.Now.Seconds;
     }
-  
-    TimeUtils.TimeFromTotalSeconds(clock.Now.Seconds, out seconds, out nanoseconds);
+
+    TimeUtils.TimeFromTotalSeconds(nowSeconds, out seconds, out nanoseconds);
   }
 
   public void Dispose()
   {
-    if (clock != null)
+    lock (clockMutex)
     {
-      clock.Dispose();
-      clock = null;
+      if (clock != null)
+      {
+        clock.Dispose();
+        clock = null;
+      }
     }
   }
 }

--- a/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs.meta
+++ b/src/Ros2ForUnity/Scripts/Time/ROS2TimeSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95fb7478971144d3ae86e914799ca990
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Time/TimeUtils.cs
+++ b/src/Ros2ForUnity/Scripts/Time/TimeUtils.cs
@@ -19,7 +19,7 @@ namespace ROS2
 {
 
 /// <summary>
-/// Interace for acquiring time
+/// Helpers for converting floating-point seconds into ROS time fields.
 /// </summary>
 internal static class TimeUtils
 {

--- a/src/Ros2ForUnity/Scripts/Time/TimeUtils.cs
+++ b/src/Ros2ForUnity/Scripts/Time/TimeUtils.cs
@@ -1,4 +1,5 @@
 // Copyright 2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace ROS2
 {
 
@@ -22,9 +25,28 @@ internal static class TimeUtils
 {
   public static void TimeFromTotalSeconds(in double secondsIn, out int seconds, out uint nanoseconds)
   {
-    long nanosec = (long)(secondsIn * 1e9);
-    seconds = (int)(nanosec / 1000000000);
-    nanoseconds = (uint)(nanosec % 1000000000);
+    if (Double.IsNaN(secondsIn) || Double.IsInfinity(secondsIn))
+    {
+      throw new ArgumentOutOfRangeException(nameof(secondsIn), "ROS time cannot be NaN or infinity");
+    }
+
+    double wholeSeconds = Math.Floor(secondsIn);
+    double fractionalSeconds = secondsIn - wholeSeconds;
+    long wholeNanoseconds = (long)Math.Round(fractionalSeconds * 1000000000.0);
+
+    if (wholeNanoseconds >= 1000000000)
+    {
+      wholeSeconds += 1.0;
+      wholeNanoseconds -= 1000000000;
+    }
+
+    if (wholeSeconds < Int32.MinValue || wholeSeconds > Int32.MaxValue)
+    {
+      throw new OverflowException("ROS time seconds exceed Int32 range");
+    }
+
+    seconds = (int)wholeSeconds;
+    nanoseconds = (uint)wholeNanoseconds;
   }
 }
 

--- a/src/Ros2ForUnity/Scripts/Time/TimeUtils.cs.meta
+++ b/src/Ros2ForUnity/Scripts/Time/TimeUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6056dc4be844b7786a8f54ad751ab2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Time/UnityTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/UnityTimeSource.cs
@@ -1,4 +1,5 @@
 // Copyright 2022 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,18 +28,35 @@ namespace ROS2
 /// </summary>
 public class UnityTimeSource : ITimeSource
 {
-  private Thread mainThread;
+  private readonly object mutex = new object();
+  private int mainThreadId;
   private double lastReadingSecs;
 
   public UnityTimeSource()
   {
-    mainThread = Thread.CurrentThread;
+    mainThreadId = Thread.CurrentThread.ManagedThreadId;
+    lastReadingSecs = Time.timeAsDouble;
   }
 
   public void GetTime(out int seconds, out uint nanoseconds)
   {
-    lastReadingSecs = mainThread.Equals(Thread.CurrentThread) ? Time.timeAsDouble : lastReadingSecs;
-    TimeUtils.TimeFromTotalSeconds(lastReadingSecs, out seconds, out nanoseconds);
+    double reading;
+    if (mainThreadId == Thread.CurrentThread.ManagedThreadId)
+    {
+      reading = Time.timeAsDouble;
+      lock (mutex)
+      {
+        lastReadingSecs = reading;
+      }
+    }
+    else
+    {
+      lock (mutex)
+      {
+        reading = lastReadingSecs;
+      }
+    }
+    TimeUtils.TimeFromTotalSeconds(reading, out seconds, out nanoseconds);
   }
 }
 

--- a/src/Ros2ForUnity/Scripts/Time/UnityTimeSource.cs
+++ b/src/Ros2ForUnity/Scripts/Time/UnityTimeSource.cs
@@ -38,7 +38,7 @@ public class UnityTimeSource : ITimeSource
     lastReadingSecs = Time.timeAsDouble;
   }
 
-  public void GetTime(out int seconds, out uint nanoseconds)
+  public bool GetTime(out int seconds, out uint nanoseconds)
   {
     double reading;
     if (mainThreadId == Thread.CurrentThread.ManagedThreadId)
@@ -51,12 +51,14 @@ public class UnityTimeSource : ITimeSource
     }
     else
     {
+      // Unity time can only be sampled on the main thread; background callers receive the last main-thread sample.
       lock (mutex)
       {
         reading = lastReadingSecs;
       }
     }
     TimeUtils.TimeFromTotalSeconds(reading, out seconds, out nanoseconds);
+    return true;
   }
 }
 

--- a/src/Ros2ForUnity/Scripts/Time/UnityTimeSource.cs.meta
+++ b/src/Ros2ForUnity/Scripts/Time/UnityTimeSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d754e026bfe4593903606e81cf15609
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ros2ForUnity/Scripts/Transformations.cs
+++ b/src/Ros2ForUnity/Scripts/Transformations.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using UnityEngine;
+using System.Runtime.CompilerServices;
 
 namespace ROS2
 {
@@ -83,6 +84,7 @@ public static class Transformations
         vector.z = y;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Matrix4x4 Unity2RosMatrix4x4()
     {
         return Unity2RosMatrix;

--- a/src/Ros2ForUnity/Scripts/Transformations.cs
+++ b/src/Ros2ForUnity/Scripts/Transformations.cs
@@ -1,4 +1,5 @@
 // Copyright 2019-2021 Robotec.ai.
+// Modifications Copyright (c) 2026 Jianbin Liu.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +22,17 @@ namespace ROS2
 /// </summary>
 public static class Transformations
 {
+    /// <summary>
+    /// Constant Unity-to-ROS coordinate transform matrix.
+    /// Unity uses x-right, y-up, z-forward; ROS uses x-forward, y-left, z-up.
+    /// </summary>
+    public static readonly Matrix4x4 Unity2RosMatrix = new Matrix4x4(
+        new Vector4( 0.0f, 0.0f, 1.0f, 0.0f),
+        new Vector4(-1.0f, 0.0f, 0.0f, 0.0f),
+        new Vector4( 0.0f, 1.0f, 0.0f, 0.0f),
+        new Vector4( 0.0f, 0.0f, 0.0f, 1.0f)
+    ).transpose;
+
     public static Vector3 Ros2Unity(this Vector3 vector3)
     {
         return new Vector3(-vector3.y, vector3.z, vector3.x);
@@ -73,14 +85,7 @@ public static class Transformations
 
     public static Matrix4x4 Unity2RosMatrix4x4()
     {
-        // Note: The matrix here is written as-if on paper,
-        // but Unity's Matrix4x4 is constructed from column-vectors, hence the transpose.
-        return new Matrix4x4(
-            new Vector4( 0.0f, 0.0f, 1.0f, 0.0f),
-            new Vector4(-1.0f, 0.0f, 0.0f, 0.0f),
-            new Vector4( 0.0f, 1.0f, 0.0f, 0.0f),
-            new Vector4( 0.0f, 0.0f, 0.0f, 1.0f)
-        ).transpose;
+        return Unity2RosMatrix;
     }
 }
 

--- a/src/scripts/metadata_generator.py
+++ b/src/scripts/metadata_generator.py
@@ -18,15 +18,20 @@ import xml.etree.ElementTree as ET
 import subprocess
 import pathlib
 import os
+import io
 
-def get_git_commit(working_directory) -> str:
-    return run_git(['rev-parse', 'HEAD'], working_directory)
+SCRIPT_DIR = pathlib.Path(__file__).parent
+R2FU_ROOT = SCRIPT_DIR.parents[1]
+R2FU_ASSET = SCRIPT_DIR.parent.joinpath("Ros2ForUnity")
+ROS2CS_PATH = SCRIPT_DIR.parent.joinpath("ros2cs")
+
+def get_git_commit_and_date(working_directory) -> tuple[str, str]:
+    output = run_git(['log', '-1', '--format=%H%n%ci'], working_directory)
+    sha, date = output.split('\n', 1)
+    return sha.strip(), date.strip()
 
 def get_git_description(working_directory) -> str:
     return run_git(['describe', '--tags', '--always'], working_directory)
-
-def get_commit_date(working_directory) -> str:
-    return run_git(['show', '-s', '--format=%ci'], working_directory)
 
 def get_git_abbrev(working_directory) -> str:
     return run_git(['rev-parse', '--abbrev-ref', 'HEAD'], working_directory)
@@ -44,15 +49,15 @@ def run_git(args, working_directory) -> str:
 
 def get_ros2_for_unity_root_path() -> pathlib.Path:
     # metadata_generator.py is expected to live under <repo>/src/scripts.
-    return pathlib.Path(__file__).parents[2]
+    return R2FU_ROOT
 
 def get_ros2_for_unity_path() -> pathlib.Path:
     # metadata_generator.py is expected to live under <repo>/src/scripts.
-    return pathlib.Path(__file__).parents[1].joinpath("Ros2ForUnity")
+    return R2FU_ASSET
 
 def get_ros2cs_path() -> pathlib.Path:
     # ros2cs is expected beside Ros2ForUnity under <repo>/src.
-    return pathlib.Path(__file__).parents[1].joinpath("ros2cs")
+    return ROS2CS_PATH
 
 def get_ros2_version() -> str:
     return os.environ.get("ROS_DISTRO", "unknown")
@@ -70,39 +75,52 @@ def main() -> None:
     parser.add_argument('--standalone', action='store_true', help='is a standalone build')
     args = parser.parse_args()
 
-    require_existing_path(get_ros2_for_unity_root_path().joinpath(".git"), "ros2-for-unity .git")
-    require_directory(get_ros2cs_path(), "ros2cs checkout")
-    require_existing_path(get_ros2cs_path().joinpath(".git"), "ros2cs .git")
-    require_directory(get_ros2_for_unity_path(), "Ros2ForUnity asset directory")
+    ros2_for_unity_root_path = get_ros2_for_unity_root_path()
+    ros2_for_unity_path = get_ros2_for_unity_path()
+    ros2cs_path = get_ros2cs_path()
+    ros2_version = get_ros2_version()
+
+    require_existing_path(ros2_for_unity_root_path.joinpath(".git"), "ros2-for-unity .git")
+    require_directory(ros2cs_path, "ros2cs checkout")
+    require_existing_path(ros2cs_path.joinpath(".git"), "ros2cs .git")
+    require_directory(ros2_for_unity_path, "Ros2ForUnity asset directory")
+
+    ros2_for_unity_sha, ros2_for_unity_date = get_git_commit_and_date(ros2_for_unity_root_path)
+    ros2cs_sha, ros2cs_date = get_git_commit_and_date(ros2cs_path)
 
     ros2_for_unity = ET.Element("ros2_for_unity")
-    ET.SubElement(ros2_for_unity, "ros2").text = get_ros2_version()
+    ET.SubElement(ros2_for_unity, "ros2").text = ros2_version
     ros2_for_unity_version = ET.SubElement(ros2_for_unity, "version")
-    ET.SubElement(ros2_for_unity_version, "sha").text = get_git_commit(get_ros2_for_unity_root_path())
-    ET.SubElement(ros2_for_unity_version, "desc").text = get_git_description(get_ros2_for_unity_root_path())
-    ET.SubElement(ros2_for_unity_version, "date").text = get_commit_date(get_ros2_for_unity_root_path())
+    ET.SubElement(ros2_for_unity_version, "sha").text = ros2_for_unity_sha
+    ET.SubElement(ros2_for_unity_version, "desc").text = get_git_description(ros2_for_unity_root_path)
+    ET.SubElement(ros2_for_unity_version, "date").text = ros2_for_unity_date
 
     ros2_cs = ET.Element("ros2cs")
-    ET.SubElement(ros2_cs, "ros2").text = get_ros2_version()
+    ET.SubElement(ros2_cs, "ros2").text = ros2_version
     ros2_cs_version = ET.SubElement(ros2_cs, "version")
-    ET.SubElement(ros2_cs_version, "sha").text = get_git_commit(get_ros2cs_path())
-    ET.SubElement(ros2_cs_version, "desc").text = get_git_description(get_ros2cs_path())
-    ET.SubElement(ros2_cs_version, "date").text = get_commit_date(get_ros2cs_path())
+    ET.SubElement(ros2_cs_version, "sha").text = ros2cs_sha
+    ET.SubElement(ros2_cs_version, "desc").text = get_git_description(ros2cs_path)
+    ET.SubElement(ros2_cs_version, "date").text = ros2cs_date
     ET.SubElement(ros2_cs, "standalone").text = str(int(args.standalone))
 
-    metadata_rf2u_file = get_ros2_for_unity_path().joinpath("metadata_ros2_for_unity.xml")
+    metadata_rf2u_file = ros2_for_unity_path.joinpath("metadata_ros2_for_unity.xml")
     write_metadata_xml(ros2_for_unity, metadata_rf2u_file)
 
-    metadata_r2cs_file = get_ros2_for_unity_path().joinpath("metadata_ros2cs.xml")
+    metadata_r2cs_file = ros2_for_unity_path.joinpath("metadata_ros2cs.xml")
     write_metadata_xml(ros2_cs, metadata_r2cs_file)
 
 def write_metadata_xml(root: ET.Element, destination: pathlib.Path) -> None:
     # ET.indent requires Python 3.9+; ROS 2 Jazzy's supported Python satisfies this.
     ET.indent(root, space="   ")
-    tree = ET.ElementTree(root)
+    buffer = io.BytesIO()
+    ET.ElementTree(root).write(buffer, encoding="utf-8", xml_declaration=True)
+    new_content = buffer.getvalue()
+    if destination.exists() and destination.read_bytes() == new_content:
+        return
+
     temporary_destination = destination.with_name(destination.name + ".tmp")
     try:
-        tree.write(temporary_destination, encoding="utf-8", xml_declaration=True)
+        temporary_destination.write_bytes(new_content)
         os.replace(temporary_destination, destination)
     finally:
         if temporary_destination.exists():

--- a/src/scripts/metadata_generator.py
+++ b/src/scripts/metadata_generator.py
@@ -15,7 +15,6 @@
 
 import argparse
 import xml.etree.ElementTree as ET
-from xml.dom import minidom
 import subprocess
 import pathlib
 import os
@@ -38,18 +37,21 @@ def run_git(args, working_directory) -> str:
             ['git'] + args,
             cwd=working_directory,
             stderr=subprocess.STDOUT,
-        ).decode('ascii').strip()
+        ).decode('utf-8', errors='replace').strip()
     except subprocess.CalledProcessError as exc:
         output = exc.output.decode('utf-8', errors='replace').strip()
         raise RuntimeError(f"git {' '.join(args)} failed in {working_directory}: {output}") from exc
 
 def get_ros2_for_unity_root_path() -> pathlib.Path:
+    # metadata_generator.py is expected to live under <repo>/src/scripts.
     return pathlib.Path(__file__).parents[2]
 
 def get_ros2_for_unity_path() -> pathlib.Path:
+    # metadata_generator.py is expected to live under <repo>/src/scripts.
     return pathlib.Path(__file__).parents[1].joinpath("Ros2ForUnity")
 
 def get_ros2cs_path() -> pathlib.Path:
+    # ros2cs is expected beside Ros2ForUnity under <repo>/src.
     return pathlib.Path(__file__).parents[1].joinpath("ros2cs")
 
 def get_ros2_version() -> str:
@@ -88,15 +90,16 @@ def main() -> None:
     ET.SubElement(ros2_cs_version, "date").text = get_commit_date(get_ros2cs_path())
     ET.SubElement(ros2_cs, "standalone").text = str(int(args.standalone))
 
-    rf2u_xmlstr = minidom.parseString(ET.tostring(ros2_for_unity)).toprettyxml(indent="   ")
     metadata_rf2u_file = get_ros2_for_unity_path().joinpath("metadata_ros2_for_unity.xml")
-    with open(str(metadata_rf2u_file), "w", encoding="utf-8") as f:
-        f.write(rf2u_xmlstr)
+    write_metadata_xml(ros2_for_unity, metadata_rf2u_file)
 
-    r2cs_xmlstr = minidom.parseString(ET.tostring(ros2_cs)).toprettyxml(indent="   ")
     metadata_r2cs_file = get_ros2_for_unity_path().joinpath("metadata_ros2cs.xml")
-    with open(str(metadata_r2cs_file), "w", encoding="utf-8") as f:
-        f.write(r2cs_xmlstr)
+    write_metadata_xml(ros2_cs, metadata_r2cs_file)
+
+def write_metadata_xml(root: ET.Element, destination: pathlib.Path) -> None:
+    ET.indent(root, space="   ")
+    tree = ET.ElementTree(root)
+    tree.write(destination, encoding="utf-8", xml_declaration=True)
 
 if __name__ == "__main__":
     main()

--- a/src/scripts/metadata_generator.py
+++ b/src/scripts/metadata_generator.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2022 Robotec.ai.
+# Modifications Copyright (c) 2026 Jianbin Liu.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,16 +25,27 @@ parser.add_argument('--standalone', action='store_true', help='is a standalone b
 args = parser.parse_args()
 
 def get_git_commit(working_directory) -> str:
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=working_directory).decode('ascii').strip()
+    return run_git(['rev-parse', 'HEAD'], working_directory)
 
 def get_git_description(working_directory) -> str:
-    return subprocess.check_output(['git', 'describe', '--tags', '--always'], cwd=working_directory).decode('ascii').strip()
+    return run_git(['describe', '--tags', '--always'], working_directory)
 
 def get_commit_date(working_directory) -> str:
-    return subprocess.check_output(['git', 'show', '-s', '--format=%ci'], cwd=working_directory).decode('ascii').strip()
+    return run_git(['show', '-s', '--format=%ci'], working_directory)
 
 def get_git_abbrev(working_directory) -> str:
-    return subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=working_directory).decode('ascii').strip()
+    return run_git(['rev-parse', '--abbrev-ref', 'HEAD'], working_directory)
+
+def run_git(args, working_directory) -> str:
+    try:
+        return subprocess.check_output(
+            ['git'] + args,
+            cwd=working_directory,
+            stderr=subprocess.STDOUT,
+        ).decode('ascii').strip()
+    except subprocess.CalledProcessError as exc:
+        output = exc.output.decode('utf-8', errors='replace').strip()
+        raise RuntimeError(f"git {' '.join(args)} failed in {working_directory}: {output}") from exc
 
 def get_ros2_for_unity_root_path() -> pathlib.Path:
     return pathlib.Path(__file__).parents[2]
@@ -49,6 +61,19 @@ def get_ros2_path() -> pathlib.Path:
 
 def get_ros2_version() -> str:
     return os.environ.get("ROS_DISTRO", "unknown")
+
+def require_existing_path(path: pathlib.Path, description: str) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"{description} not found: {path}")
+
+def require_directory(path: pathlib.Path, description: str) -> None:
+    if not path.is_dir():
+        raise FileNotFoundError(f"{description} not found: {path}")
+
+require_existing_path(get_ros2_for_unity_root_path().joinpath(".git"), "ros2-for-unity .git")
+require_directory(get_ros2cs_path(), "ros2cs checkout")
+require_existing_path(get_ros2cs_path().joinpath(".git"), "ros2cs .git")
+require_directory(get_ros2_for_unity_path(), "Ros2ForUnity asset directory")
 
 ros2_for_unity = ET.Element("ros2_for_unity")
 ET.SubElement(ros2_for_unity, "ros2").text = get_ros2_version()
@@ -67,10 +92,10 @@ ET.SubElement(ros2_cs, "standalone").text = str(int(args.standalone))
 
 rf2u_xmlstr = minidom.parseString(ET.tostring(ros2_for_unity)).toprettyxml(indent="   ")
 metadata_rf2u_file = get_ros2_for_unity_path().joinpath("metadata_ros2_for_unity.xml")
-with open(str(metadata_rf2u_file), "w") as f:
+with open(str(metadata_rf2u_file), "w", encoding="utf-8") as f:
     f.write(rf2u_xmlstr)
     
 r2cs_xmlstr = minidom.parseString(ET.tostring(ros2_cs)).toprettyxml(indent="   ")
 metadata_r2cs_file = get_ros2_for_unity_path().joinpath("metadata_ros2cs.xml")
-with open(str(metadata_r2cs_file), "w") as f:
+with open(str(metadata_r2cs_file), "w", encoding="utf-8") as f:
     f.write(r2cs_xmlstr)

--- a/src/scripts/metadata_generator.py
+++ b/src/scripts/metadata_generator.py
@@ -20,10 +20,6 @@ import subprocess
 import pathlib
 import os
 
-parser = argparse.ArgumentParser(description='Generate metadata file for ros2-for-unity.')
-parser.add_argument('--standalone', action='store_true', help='is a standalone build')
-args = parser.parse_args()
-
 def get_git_commit(working_directory) -> str:
     return run_git(['rev-parse', 'HEAD'], working_directory)
 
@@ -56,9 +52,6 @@ def get_ros2_for_unity_path() -> pathlib.Path:
 def get_ros2cs_path() -> pathlib.Path:
     return pathlib.Path(__file__).parents[1].joinpath("ros2cs")
 
-def get_ros2_path() -> pathlib.Path:
-    return get_ros2cs_path().joinpath("src").joinpath("ros2").joinpath("rcl_interfaces")
-
 def get_ros2_version() -> str:
     return os.environ.get("ROS_DISTRO", "unknown")
 
@@ -70,32 +63,40 @@ def require_directory(path: pathlib.Path, description: str) -> None:
     if not path.is_dir():
         raise FileNotFoundError(f"{description} not found: {path}")
 
-require_existing_path(get_ros2_for_unity_root_path().joinpath(".git"), "ros2-for-unity .git")
-require_directory(get_ros2cs_path(), "ros2cs checkout")
-require_existing_path(get_ros2cs_path().joinpath(".git"), "ros2cs .git")
-require_directory(get_ros2_for_unity_path(), "Ros2ForUnity asset directory")
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate metadata file for ros2-for-unity.')
+    parser.add_argument('--standalone', action='store_true', help='is a standalone build')
+    args = parser.parse_args()
 
-ros2_for_unity = ET.Element("ros2_for_unity")
-ET.SubElement(ros2_for_unity, "ros2").text = get_ros2_version()
-ros2_for_unity_version = ET.SubElement(ros2_for_unity, "version")
-ET.SubElement(ros2_for_unity_version, "sha").text = get_git_commit(get_ros2_for_unity_root_path())
-ET.SubElement(ros2_for_unity_version, "desc").text = get_git_description(get_ros2_for_unity_root_path())
-ET.SubElement(ros2_for_unity_version, "date").text = get_commit_date(get_ros2_for_unity_root_path())
+    require_existing_path(get_ros2_for_unity_root_path().joinpath(".git"), "ros2-for-unity .git")
+    require_directory(get_ros2cs_path(), "ros2cs checkout")
+    require_existing_path(get_ros2cs_path().joinpath(".git"), "ros2cs .git")
+    require_directory(get_ros2_for_unity_path(), "Ros2ForUnity asset directory")
 
-ros2_cs = ET.Element("ros2cs")
-ET.SubElement(ros2_cs, "ros2").text = get_ros2_version()
-ros2_cs_version = ET.SubElement(ros2_cs, "version")
-ET.SubElement(ros2_cs_version, "sha").text = get_git_commit(get_ros2cs_path())
-ET.SubElement(ros2_cs_version, "desc").text = get_git_description(get_ros2cs_path())
-ET.SubElement(ros2_cs_version, "date").text = get_commit_date(get_ros2cs_path())
-ET.SubElement(ros2_cs, "standalone").text = str(int(args.standalone))
+    ros2_for_unity = ET.Element("ros2_for_unity")
+    ET.SubElement(ros2_for_unity, "ros2").text = get_ros2_version()
+    ros2_for_unity_version = ET.SubElement(ros2_for_unity, "version")
+    ET.SubElement(ros2_for_unity_version, "sha").text = get_git_commit(get_ros2_for_unity_root_path())
+    ET.SubElement(ros2_for_unity_version, "desc").text = get_git_description(get_ros2_for_unity_root_path())
+    ET.SubElement(ros2_for_unity_version, "date").text = get_commit_date(get_ros2_for_unity_root_path())
 
-rf2u_xmlstr = minidom.parseString(ET.tostring(ros2_for_unity)).toprettyxml(indent="   ")
-metadata_rf2u_file = get_ros2_for_unity_path().joinpath("metadata_ros2_for_unity.xml")
-with open(str(metadata_rf2u_file), "w", encoding="utf-8") as f:
-    f.write(rf2u_xmlstr)
-    
-r2cs_xmlstr = minidom.parseString(ET.tostring(ros2_cs)).toprettyxml(indent="   ")
-metadata_r2cs_file = get_ros2_for_unity_path().joinpath("metadata_ros2cs.xml")
-with open(str(metadata_r2cs_file), "w", encoding="utf-8") as f:
-    f.write(r2cs_xmlstr)
+    ros2_cs = ET.Element("ros2cs")
+    ET.SubElement(ros2_cs, "ros2").text = get_ros2_version()
+    ros2_cs_version = ET.SubElement(ros2_cs, "version")
+    ET.SubElement(ros2_cs_version, "sha").text = get_git_commit(get_ros2cs_path())
+    ET.SubElement(ros2_cs_version, "desc").text = get_git_description(get_ros2cs_path())
+    ET.SubElement(ros2_cs_version, "date").text = get_commit_date(get_ros2cs_path())
+    ET.SubElement(ros2_cs, "standalone").text = str(int(args.standalone))
+
+    rf2u_xmlstr = minidom.parseString(ET.tostring(ros2_for_unity)).toprettyxml(indent="   ")
+    metadata_rf2u_file = get_ros2_for_unity_path().joinpath("metadata_ros2_for_unity.xml")
+    with open(str(metadata_rf2u_file), "w", encoding="utf-8") as f:
+        f.write(rf2u_xmlstr)
+
+    r2cs_xmlstr = minidom.parseString(ET.tostring(ros2_cs)).toprettyxml(indent="   ")
+    metadata_r2cs_file = get_ros2_for_unity_path().joinpath("metadata_ros2cs.xml")
+    with open(str(metadata_r2cs_file), "w", encoding="utf-8") as f:
+        f.write(r2cs_xmlstr)
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/metadata_generator.py
+++ b/src/scripts/metadata_generator.py
@@ -97,6 +97,7 @@ def main() -> None:
     write_metadata_xml(ros2_cs, metadata_r2cs_file)
 
 def write_metadata_xml(root: ET.Element, destination: pathlib.Path) -> None:
+    # ET.indent requires Python 3.9+; ROS 2 Jazzy's supported Python satisfies this.
     ET.indent(root, space="   ")
     tree = ET.ElementTree(root)
     tree.write(destination, encoding="utf-8", xml_declaration=True)

--- a/src/scripts/metadata_generator.py
+++ b/src/scripts/metadata_generator.py
@@ -100,7 +100,13 @@ def write_metadata_xml(root: ET.Element, destination: pathlib.Path) -> None:
     # ET.indent requires Python 3.9+; ROS 2 Jazzy's supported Python satisfies this.
     ET.indent(root, space="   ")
     tree = ET.ElementTree(root)
-    tree.write(destination, encoding="utf-8", xml_declaration=True)
+    temporary_destination = destination.with_name(destination.name + ".tmp")
+    try:
+        tree.write(temporary_destination, encoding="utf-8", xml_declaration=True)
+        os.replace(temporary_destination, destination)
+    finally:
+        if temporary_destination.exists():
+            temporary_destination.unlink()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- Use Unicode `_wputenv_s` for Windows CRT environment updates so standalone paths with non-ASCII characters are preserved.
- Check CRT environment update failures and fail initialization with a clear error instead of continuing with a partially configured runtime.
- Explicitly set `ROS2CS_SPIN_FALLBACK=direct` for Lyrical standalone builds, while preserving user overrides.
- Update `ros2cs.repos` to pin the ros2cs dependency to the Phase 18 CI import fix.

## Dependency Note

This PR depends on the ros2cs Phase 18 branch being merged with a normal merge commit.

Pinned ros2cs commit:

`66ebf542837428b8d0d6069d71f7fc07c393c1a0`

## Validation

- `git diff --check` passed.
- Static checks confirmed:
  - no remaining ANSI `_putenv_s` binding
  - Lyrical standalone now sets `ROS2CS_SPIN_FALLBACK=direct`
- Full Unity/Player validation was not rerun in Codex because the sandbox cannot access the required local GitHub/network environment.